### PR TITLE
Updates to dreq_content

### DIFF
--- a/sandbox/MS/README.MD
+++ b/sandbox/MS/README.MD
@@ -26,11 +26,11 @@ Load the JSON file for the specified version.
 * `version`: The version to load. Can be 'latest', 'latest_stable', 'dev', or a specific version/branch, eg. '1.0.0'. Default is 'latest_stable'. Will attempt to `retrieve` the version to the local cache if needed.
 * Returns: A dictionary containing the loaded JSON data.
 
-### `get_versions(list_branches=False)`
+### `get_versions(target="tags")`
 
 Fetch the list of available versions (tags and main development branch).
 
-* `list_branches`: If True, lists branches instead of tags. The main development branch is excluded.
+* `target`: Can be 'tags' or 'branches'. The main development branch is excluded from 'branches' and considered under 'tags'.
 * Returns: A list of available versions.
 
 ### `get_cached()`
@@ -53,13 +53,16 @@ Delete one or all cached versions with option to keep latest versions.
 import dreq_content as dc
 
 # Retrieve the latest stable version
-dc.retrieve("latest_stable")
+version_dict = dc.retrieve("latest_stable")
+print(version_dict)
 
 # List all available branches
-dc.get_versions(list_branches=True)
+branches = dc.get_versions('branches')
+print(branches)
 
 # Retrieve a certain branch/tag
-dc.retrieve("v1.0alpha")
+version_dict = dc.retrieve("v1.0alpha")
+print(version_dict)
 
 # Load the latest stable version
 dreq = dc.load("latest_stable")

--- a/sandbox/MS/README.MD
+++ b/sandbox/MS/README.MD
@@ -15,7 +15,7 @@ The following functions are available for use:
 Retrieve the JSON file for the specified version.
 
 * `version`: The version to retrieve. Can be 'latest', 'latest_stable', 'dev', or a specific version, eg. '1.0.0', or even a branch like 'first_export'.
-             'dev' points to the 'main' branch. In case of 'latest' or 'latest_stable', the tags on GitHub will be taken into account.
+             'dev' points to the main development branch (in this case 'main'). In case of 'latest' or 'latest_stable', the tags on GitHub will be taken into account.
              Default is 'latest_stable'.
 * Returns: A dictionary containing the path to the retrieved JSON file.
 
@@ -26,12 +26,16 @@ Load the JSON file for the specified version.
 * `version`: The version to load. Can be 'latest', 'latest_stable', 'dev', or a specific version/branch, eg. '1.0.0'. Default is 'latest_stable'. Will attempt to `retrieve` the version to the local cache if needed.
 * Returns: A dictionary containing the loaded JSON data.
 
-### `get_versions(local=False)`
+### `get_versions(list_branches=False)`
 
-Fetch the list of available versions.
+Fetch the list of available versions (tags and main development branch).
 
-* `local`: If True, lists only locally cached versions. If False, retrieves list of versions remotely. Default is False.
+* `list_branches`: If True, lists branches instead of tags. The main development branch is excluded.
 * Returns: A list of available versions.
+
+### `get_cached()`
+
+* Returns: A list of locally cached versions (tags and branches).
 
 ### `delete(version="all", keep_latest=False)`
 
@@ -49,17 +53,23 @@ Delete one or all cached versions with option to keep latest versions.
 import dreq_content as dc
 
 # Retrieve the latest stable version
-dc.dreq_content.retrieve("first_export")
+dc.retrieve("latest_stable")
+
+# List all available branches
+dc.get_versions(list_branches=True)
+
+# Retrieve a certain branch/tag
+dc.retrieve("v1.0alpha")
 
 # Load the latest stable version
-dreq = dc.load("first_export")
+dreq = dc.load("latest_stable")
 
 # Get the list of available versions
 versions = dc.get_versions()
 print(versions)
 
 # Get list of locally cached versions
-versions = dc.get_versions(local=True)
+versions = dc.get_cached()
 print(versions)
 
 # Delete all cached versions except the latest, latest stable and "dev" versions

--- a/sandbox/MS/README.MD
+++ b/sandbox/MS/README.MD
@@ -46,36 +46,61 @@ Delete one or all cached versions with option to keep latest versions.
                  Has no application if `version` is not `"all"`. Note that 'latest' and 'latest_stable' apply on the locally cached
                  versions only. More recent versions that might be available online are not considered. Default is False.
 
+### Function `kwargs`
+
+Mainly to support the development and not intended for common usage, some functions allow `kwargs`to be passed
+These are:
+- export: "raw" or "release" (supported for `get_cached`, `retrieve`, `load`, `delete`)
+  whether to respect the raw or release export json file. Per default, for official releases / tags, the release export json file is processed,
+  and else the raw export json file.
+- consolidate: True or False (supported for `load`)
+  whether to consolidate in case a raw export json file is loaded. The default is to consolidate.
+- dryrun: True or False (supported for `delete`)
+  whether to only list the files that would be deleted instead of actually deleting them. The default is to delete the files and not to list them.
+
 **Usage Examples**
 -----------------
 
 ```python
 import dreq_content as dc
 
-# Retrieve the latest stable version
-version_dict = dc.retrieve("latest_stable")
-print(version_dict)
+# Get the list of available versions
+versions = dc.get_versions()
+print(versions)
 
 # List all available branches
 branches = dc.get_versions('branches')
 print(branches)
 
+# Retrieve the latest stable version
+version_dict = dc.retrieve() # or dc.retrieve("latest_stable")
+print(version_dict)
+
 # Retrieve a certain branch/tag
-version_dict = dc.retrieve("v1.0alpha")
+version_dict = dc.retrieve("v1.0beta")
+print(version_dict)
+
+# Retrieve all available releases
+version_dict = dc.retrieve("all")
 print(version_dict)
 
 # Load the latest stable version
-dreq = dc.load("latest_stable")
+dreq = dc.load() # or dc.load("latest_stable")
 
-# Get the list of available versions
-versions = dc.get_versions()
-print(versions)
+# Load the latest version
+dreq = dc.load("latest")
+
+# Load the development version
+dreq = dc.load("dev")
 
 # Get list of locally cached versions
 versions = dc.get_cached()
 print(versions)
 
 # Delete all cached versions except the latest, latest stable and "dev" versions
-dreq_content.delete(keep_latest=True)
+dc.delete(keep_latest=True)
+
+# Delete a certain version
+dc.delete("v1.0alpha")
 ```
 

--- a/sandbox/MS/dreq_api/consolidate_export.py
+++ b/sandbox/MS/dreq_api/consolidate_export.py
@@ -143,8 +143,7 @@ def map_data(data, mapping_table):
         return mapped_data
     # Return the data if it is already one-base
     elif len(data.keys()) == 1:
-        mapped_data["Data Request"] = data[data.keys()[0]]
-        return mapped_data
+        return {"Data Request": next(iter(data.values()))}
     else:
         raise ValueError("The loaded Data Request has an unexpected data structure.")
 

--- a/sandbox/MS/dreq_api/consolidate_export.py
+++ b/sandbox/MS/dreq_api/consolidate_export.py
@@ -1,0 +1,416 @@
+import re
+import warnings
+
+
+def map_data(data, mapping_table):
+    """
+    Maps the data to the one-base structure using the mapping table.
+
+    Args:
+        data: dict (three-base or one-base Airtable export)
+        mapping_table: The mapping table to apply to map to one base.
+
+    Returns:
+        dict: of the mapped data with one-base structure.
+
+    Note:
+        Returns the input dict if the data is already one-base.
+    """
+    missing_bases = []
+    missing_tables = []
+    mapped_data = {"Data Request": {}}
+    # Perform mapping in case of three-base structure
+    if len(data.keys()) in [3, 4]:
+        for table, mapinfo in mapping_table.items():
+            intm = mapinfo["internal_mapping"]
+            if (
+                mapinfo["source_base"] in data
+                and mapinfo["source_table"] in data[mapinfo["source_base"]]
+            ):
+
+                # Copy the selected data to the one-base structure
+                # print(f"Mapping '{mapinfo['source_base']}' -> '{table}'")
+                mapped_data["Data Request"][table] = data[mapinfo["source_base"]][
+                    mapinfo["source_table"]
+                ]
+
+                # If record attributes require mapping
+                if intm != {}:
+                    # for each attribute that requires mapping
+                    for attr in intm.keys():
+                        for record_id, record in data[mapinfo["source_base"]][
+                            mapinfo["source_table"]
+                        ]["records"].items():
+                            if (
+                                attr not in record
+                                or record[attr] is None
+                                or record[attr] == ""
+                                or record[attr] == []
+                            ):
+                                print(
+                                    f"{table}: Attribute '{attr}' not found for record '{record_id}'."
+                                )
+                                continue
+                            attr_vals = record[attr]
+
+                            # operation
+                            if intm[attr]["operation"] == "split":
+                                attr_vals = re.split(r"\s*,\s*", attr_vals)
+                            elif intm[attr]["operation"] == "":
+                                if isinstance(attr_vals, str):
+                                    attr_vals = [attr_vals]
+                            else:
+                                raise ValueError(
+                                    f"Unknown internal mapping operation for attribute '{attr}' ('{mapinfo['source_table']}'): '{intm[attr]['operation']}'"
+                                )
+
+                            # Get mapped record_ids
+                            # entry_type - single record_id or list of record_ids
+                            if intm[attr]["entry_type"] == "record_id":
+                                if not intm[attr]["base_copy_of_table"]:
+                                    raise ValueError(
+                                        "A copy of the table in the same base is required if 'entry_type' is set to 'record_id', "
+                                        f"but 'base_copy_of_table' is set to False: '{mapinfo['source_table']}' - '{attr}'"
+                                    )
+                                elif not intm[attr]["base"] in data:
+                                    raise KeyError(
+                                        f"Base '{intm[attr]['base']}' not found in data."
+                                    )
+                                elif (
+                                    intm[attr]["base_copy_of_table"]
+                                    not in data[mapinfo["source_base"]]
+                                ):
+                                    raise KeyError(
+                                        f"Table '{intm[attr]['table']}' not found in base '{intm[attr]['base_copy']}'."
+                                    )
+                                recordIDs_new = []
+                                for attr_val in attr_vals:
+                                    # The record copy in the current base
+                                    record_copy = data[mapinfo["source_base"]][
+                                        intm[attr]["base_copy_of_table"]
+                                    ]["records"][attr_val]
+                                    # The entire list of records in the base of origin
+                                    recordlist = data[intm[attr]["base"]][
+                                        intm[attr]["table"]
+                                    ]["records"]
+                                    recordIDs_new.append(
+                                        _map_record_id(
+                                            record_copy,
+                                            recordlist,
+                                            intm[attr]["map_by_key"],
+                                        )
+                                    )
+                            # entry_type - name (eg. unique label or similar)
+                            elif intm[attr]["entry_type"] == "name":
+                                recordIDs_new = []
+                                for attr_val in attr_vals:
+                                    recordIDs_new.append(
+                                        _map_attribute(
+                                            attr_val,
+                                            data[intm[attr]["base"]][
+                                                intm[attr]["table"]
+                                            ]["records"],
+                                            (
+                                                intm[attr]["map_by_key"]
+                                                if isinstance(
+                                                    intm[attr]["map_by_key"], str
+                                                )
+                                                else intm[attr]["map_by_key"][0]
+                                            ),
+                                        )
+                                    )
+                            else:
+                                raise ValueError(
+                                    f"Unknown 'entry_type' specified for attribute '{attr}' ('{mapinfo['source_table']}'): '{intm[attr]['entry_type']}'"
+                                )
+                            mapped_data["Data Request"][table]["records"][record_id][
+                                attr
+                            ] = recordIDs_new
+
+            else:
+                if mapinfo["source_base"] not in data:
+                    missing_tables.append(mapinfo["source_base"])
+                elif mapinfo["source_table"] not in data[mapinfo["source_base"]]:
+                    missing_bases.append(mapinfo["source_table"])
+        if len(missing_bases) > 0:
+            warnings.warn(
+                f"Encountered missing bases when consolidating the data: {set(missing_bases)}"
+            )
+        if len(missing_tables) > 0:
+            warnings.warn(
+                f"Encountered missing tables when consolidating the data: {missing_tables}"
+            )
+        return mapped_data
+    # Return the data if it is already one-base
+    elif len(data.keys()) == 1:
+        mapped_data["Data Request"] = data[data.keys()[0]]
+        return mapped_data
+    else:
+        raise ValueError("The loaded Data Request has an unexpected data structure.")
+
+
+def _map_record_id(record, records, keys):
+    """
+    Identifies a record_id in list of records using key
+    """
+    matches = []
+    for key in keys:
+        if key in record:
+            recval = record[key]
+            matches = [r for r, v in records.items() if key in v and v[key] == recval]
+            if len(matches) == 1:
+                break
+    if len(matches) == 1:
+        return matches[0]
+    else:
+        raise KeyError(f"None or multiple matches when consolidating '{record}'.")
+
+
+def _map_attribute(attr, records, key):
+    """
+    Identifies a record_id in list of records using key and matching with the attribute value.
+    """
+    matches = [r for r, v in records.items() if key in v and v[key] == attr]
+    if len(matches) == 1:
+        return matches[0]
+    elif len(matches) == 0:
+        # raise KeyError(f"No matches when consolidating '{attr}' via '{key}'.")
+        print(f"No matches when consolidating '{attr}' via '{key}'.")
+    else:
+        # raise KeyError(f"Multiple matches when consolidating '{attr}' via '{key}'.")
+        print(f"Multiple matches when consolidating '{attr}' via '{key}'.")
+
+
+"""
+Mapping Table
+
+The mapping_table dictionary defines how to map the three-base structure to the one-base structure.
+Each entry in the dictionary represents a table in the one-base structure and includes the information
+how to obtain it from the three-base structure.
+
+Explanation of the dictionary keys:
+
+Base ("source_base"):
+   The base containing the table to be selected.
+
+Table ("source_table"):
+    The table to be selected from the "source_base".
+
+Internal Mapping of record attributes ("internal_mapping"):
+    Record attributes may point to records of other tables.
+    However, there is no cross-linkage between the three bases,
+    so these links need to be mapped as well.
+    "internal_mapping" is a dictionary with the key corresponding
+    to the record attributes to be mapped and the values containing
+    the actual mapping information.
+
+    The mapping information is again a dictionary with the following keys:
+    - base_copy_of_table:
+        If a copy of table corresponding to the record attribute exists in the current base,
+        provide the name; otherwise, set to False.
+    - base:
+        The base containing the original table the record attribute points to.
+    - table:
+        The original table the record attribute points to.
+    - operation:
+        The operation to perform on the attribute value (either "split" or "", if it is
+        already provided as list or a string without comma separated values).
+    - map_by_key:
+        A list of keys to map by.
+    - entry_type:
+        The type of entry (either "record_id" or "name").
+
+Example Configuration
+
+Suppose we want to map the "CMIP7 Variable Groups" key in the "Variables" table of the "Data Request Variables (Public)"
+base to a list of record IDs of "Variable Group" records in the "Data Request Opportunities (Public)" base.
+
+We would define the mapping_table as follows:
+mapping_table = {
+      "Variables": {
+                "base": "Data Request Variables (Public)",
+                "source_table": "Variables",
+                "internal_mapping": {
+                    "CMIP7 Variable Groups": {
+                        "base_copy_of_table": False,
+                        "base": "Data Request Opportunities (Public)",
+                        "table": "Variable Group",
+                        "operation": "split",
+                        "map_by_key": ["Name"],
+                        "entry_type": "name",
+                    },
+                },
+      },
+}
+"""
+mapping_table = {
+    "Opportunity": {
+        "source_base": "Data Request Opportunities (Public)",
+        "source_table": "Opportunity",
+        "internal_mapping": {},
+    },
+    "Variable Group": {
+        "source_base": "Data Request Opportunities (Public)",
+        "source_table": "Variable Group",
+        "internal_mapping": {
+            "Variables": {
+                "base_copy_of_table": "Variables",
+                "base": "Data Request Variables (Public)",
+                "table": "Variable",
+                "operation": "",
+                "map_by_key": ["UID", "Compound Name"],
+                "entry_type": "record_id",
+            },
+        },
+    },
+    "Variables": {
+        "source_base": "Data Request Variables (Public)",
+        "source_table": "Variable",
+        "internal_mapping": {
+            "CMIP7 Variable Groups": {
+                "base_copy_of_table": False,
+                "base": "Data Request Opportunities (Public)",
+                "table": "Variable Group",
+                "operation": "split",
+                "map_by_key": ["Name"],
+                "entry_type": "name",
+            },
+            "Physical Parameter": {
+                "base_copy_of_table": "Physical Parameter",
+                "base": "Data Request Physical Parameters (Public)",
+                "table": "Physical Parameter",
+                "operation": "",
+                "map_by_key": ["UID", "Name"],
+                "entry_type": "record_id",
+            },
+            "CF Standard Name (from MIP Variables)": {
+                "base_copy_of_table": False,
+                "base": "Data Request Physical Parameters (Public)",
+                "table": "CF Standard Name",
+                "operation": "",
+                "map_by_key": ["name"],
+                "entry_type": "name",
+            },
+        },
+    },
+    "Experiment Group": {
+        "source_base": "Data Request Opportunities (Public)",
+        "source_table": "Experiment Group",
+        "internal_mapping": {},
+    },
+    "Experiments": {
+        "source_base": "Data Request Opportunities (Public)",
+        "source_table": "Experiment",
+        "internal_mapping": {},
+    },
+    "Physical Parameters": {
+        "source_base": "Data Request Physical Parameters (Public)",
+        "source_table": "Physical Parameter",
+        "internal_mapping": {},
+    },
+    "MIPs": {
+        "source_base": "Data Request Opportunities (Public)",
+        "source_table": "MIP",
+        "internal_mapping": {},
+    },
+    "Data Request Themes": {
+        "source_base": "Data Request Opportunities (Public)",
+        "source_table": "Data Request Themes",
+        "internal_mapping": {},
+    },
+    "Priority Level": {
+        "source_base": "Data Request Opportunities (Public)",
+        "source_table": "Priority Level",
+        "internal_mapping": {},
+    },
+    "Docs for Opportunities": {
+        "source_base": "Data Request Opportunities (Public)",
+        "source_table": "Docs for Opportunities",
+        "internal_mapping": {},
+    },
+    "Time Slice": {
+        "source_base": "Data Request Opportunities (Public)",
+        "source_table": "Time Slice",
+        "internal_mapping": {},
+    },
+    "Opportunity/Variable Group Comments": {
+        "source_base": "Data Request Opportunities (Public)",
+        "source_table": "Comment",
+        "internal_mapping": {},
+    },
+    "Glossary": {
+        "source_base": "Data Request Opportunities (Public)",
+        "source_table": "Glossary",
+        "internal_mapping": {},
+    },
+    "Modelling Realm": {
+        "source_base": "Data Request Variables (Public)",
+        "source_table": "Modelling Realm",
+        "internal_mapping": {},
+    },
+    "Frequency": {
+        "source_base": "Data Request Variables (Public)",
+        "source_table": "Frequency",
+        "internal_mapping": {},
+    },
+    "Table Identifiers": {
+        "source_base": "Data Request Variables (Public)",
+        "source_table": "Table Identifiers",
+        "internal_mapping": {},
+    },
+    "Spatial Shape": {
+        "source_base": "Data Request Variables (Public)",
+        "source_table": "Spatial Shape",
+        "internal_mapping": {},
+    },
+    "Temporal Shape": {
+        "source_base": "Data Request Variables (Public)",
+        "source_table": "Temporal Shape",
+        "internal_mapping": {},
+    },
+    "Structure": {
+        "source_base": "Data Request Variables (Public)",
+        "source_table": "Structure",
+        "internal_mapping": {},
+    },
+    "Cell Methods": {
+        "source_base": "Data Request Variables (Public)",
+        "source_table": "Cell Methods",
+        "internal_mapping": {},
+    },
+    "Cell Measures": {
+        "source_base": "Data Request Variables (Public)",
+        "source_table": "Cell Measures",
+        "internal_mapping": {},
+    },
+    "Coordinates and Dimensions": {
+        "source_base": "Data Request Variables (Public)",
+        "source_table": "Coordinate or Dimension",
+        "internal_mapping": {},
+    },
+    "Ranking": {
+        "source_base": "Data Request Variables (Public)",
+        "source_table": "Ranking",
+        "internal_mapping": {},
+    },
+    "Variable Comments": {
+        "source_base": "Data Request Variables (Public)",
+        "source_table": "Comment",
+        "internal_mapping": {},
+    },
+    "ESM-BCV 1.3": {
+        "source_base": "Data Request Variables (Public)",
+        "source_table": "ESM-BCV 1.3",
+        "internal_mapping": {},
+    },
+    "CF Standard Names": {
+        "source_base": "Data Request Physical Parameters (Public)",
+        "source_table": "CF Standard Name",
+        "internal_mapping": {},
+    },
+    "Physical Parameter Comments": {
+        "source_base": "Data Request Physical Parameters (Public)",
+        "source_table": "Comment",
+        "internal_mapping": {},
+    },
+}

--- a/sandbox/MS/dreq_api/test_dreq_content.py
+++ b/sandbox/MS/dreq_api/test_dreq_content.py
@@ -19,6 +19,8 @@ def test_get_versions():
     "Test the get_versions function."
     versions = dc.get_versions()
     assert "dev" in versions
+    assert "v1.0alpha" in versions
+    assert "v1.0beta" in versions
 
 
 def test_get_versions_list_branches():
@@ -26,14 +28,21 @@ def test_get_versions_list_branches():
     branches = dc.get_versions(target="branches")
     assert "dev" not in branches
     assert "main" not in branches
-    assert len(branches) > 0
+
+
+def test_get_latest_version(monkeypatch):
+    "Test the _get_latest_version function."
+    monkeypatch.setattr(dc, "get_versions", lambda: ["1.0.0", "2.0.2b", "2.0.2a"])
+    assert dc._get_latest_version() == "1.0.0"
+    assert dc._get_latest_version(stable=False) == "2.0.2b"
 
 
 def test_get_cached(tmp_path):
+    "Test the get_cached function."
     # Create a temporary directory with a subdirectory containing a dreq.json file
     version_dir = tmp_path / "v1.0.0"
     version_dir.mkdir()
-    (version_dir / dc._json_export).touch()
+    (version_dir / dc._json_release).touch()
 
     # Set the _dreq_res variable to the temporary directory
     dc._dreq_res = str(tmp_path)
@@ -72,7 +81,7 @@ def test_retrieve(tmp_path, capfd):
 def test_retrieve_with_invalid_version(tmp_path):
     "Test the retrieval function with an invalid version."
     dc._dreq_res = str(tmp_path)
-    with pytest.warns(UserWarning, match="Could not retrieve version"):
+    with pytest.raises(ValueError):
         dc.retrieve(" invalid-version ")
 
 
@@ -91,10 +100,95 @@ def test_load(tmp_path):
     "Test the load function."
     dc._dreq_res = str(tmp_path)
 
-    with pytest.warns(UserWarning, match="Could not retrieve version"):
-        with pytest.raises(KeyError):
-            jsondict = dc.load(" invalid-version ")
+    with pytest.raises(ValueError):
+        jsondict = dc.load(" invalid-version ")
 
     jsondict = dc.load("dev")
     assert isinstance(jsondict, dict)
-    assert os.path.isfile(tmp_path / "dev" / dc._json_export)
+    assert os.path.isfile(tmp_path / "dev" / dc._json_raw)
+    assert not os.path.isfile(tmp_path / "dev" / dc._json_release)
+
+    jsondict = dc.load("dev", export="release")
+    assert isinstance(jsondict, dict)
+    assert os.path.isfile(tmp_path / "dev" / dc._json_release)
+
+
+class TestDreqContent:
+    """
+    Test various functions of the dreq_content module.
+    """
+
+    @pytest.fixture(autouse=True, scope="function")
+    def setup(self, tmp_path):
+        self.versions = ["v1.0.0", "1.0.1", "2.0.1b", "2.0.1", "2.0.2b"]
+        self.branches = ["one", "or", "another"]
+        self.dreq_res = tmp_path
+        for v in self.versions:
+            (self.dreq_res / v).mkdir()
+            (self.dreq_res / v / dc._json_release).write_text("{}")
+        for b in self.branches:
+            (self.dreq_res / b).mkdir()
+            (self.dreq_res / b / dc._json_raw).write_text("{}")
+
+    def test_get_cached(self):
+        "Test the get_cached function."
+        dc._dreq_res = self.dreq_res
+        # Basic
+        cached_versions = dc.get_cached()
+        assert set(cached_versions) == set(self.versions + self.branches)
+
+        # With export kwarg "release"
+        cached_tags = dc.get_cached(export="release")
+        assert set(cached_tags) == set(self.versions)
+
+        # With export kwarg "raw"
+        cached_branches = dc.get_cached(export="raw")
+        assert set(cached_branches) == set(self.branches)
+
+        # With invalid export kwarg
+        with pytest.warns(UserWarning, match="Unknown export type"):
+            dc.get_cached(export="invalid")
+
+    def test_delete(self, capfd):
+        "Test the delete function."
+        dc._dreq_res = self.dreq_res
+        # Delete non-existent version
+        dc.delete("notpresent")
+        stdout = capfd.readouterr().out.splitlines()
+        assert len(stdout) == 1
+        assert "No version(s) found to delete." in stdout
+
+        # Delete only branches / dryrun
+        dc.delete("all", export="raw", dryrun=True)
+        stdout = capfd.readouterr().out.splitlines()
+        assert len(stdout) == 5
+        assert "Deleting the following version(s):" in stdout
+        for b in self.branches:
+            assert (
+                f"Dryrun: would delete '{dc._dreq_res / b / dc._json_raw}'." in stdout
+            )
+
+        # Delete all but latest
+        dc.delete(keep_latest=True)
+        assert set(dc.get_cached()) == {"2.0.1", "2.0.2b"}
+        assert dc.get_cached(export="raw") == []
+
+        # Delete 2.0.1 with warning
+        with pytest.warns(UserWarning, match=" option is ignored "):
+            dc.delete("2.0.1", keep_latest=True)
+
+        # Delete all with ValueError for kwargs
+        with pytest.raises(ValueError):
+            dc.delete(export="none")
+
+        # Delete all
+        dc.delete()
+        assert dc.get_cached() == []
+
+        # Now there is no ValueError since no version is found
+        dc.delete(export="none")
+
+    # def test_load(self):
+    #    dc._dreq_res = self.tmp_dir.name
+    #    data = dc.load("1.0.0")
+    #    assert data == {}

--- a/sandbox/MS/dreq_api/test_dreq_content.py
+++ b/sandbox/MS/dreq_api/test_dreq_content.py
@@ -1,0 +1,100 @@
+import os
+
+import dreq_content as dc
+import pytest
+
+
+def test_parse_version():
+    "Test the _parse_version function with different version strings."
+    assert dc._parse_version("v1.0.0") == (1, 0, 0, "", 0)
+    assert dc._parse_version("v1.0alpha2") == (1, 0, 0, "a", 2)
+    assert dc._parse_version("1.0.0a3") == (1, 0, 0, "a", 3)
+    assert dc._parse_version("1.0.0beta") == (1, 0, 0, "b", 0)
+    assert dc._parse_version("something") == (0, 0, 0, "", 0)
+    with pytest.raises(TypeError):
+        dc._parse_version(None)
+
+
+def test_get_versions():
+    "Test the get_versions function."
+    versions = dc.get_versions()
+    assert "dev" in versions
+
+
+def test_get_versions_list_branches():
+    "Test the get_versions function for branches."
+    branches = dc.get_versions(target="branches")
+    assert "dev" not in branches
+    assert "main" not in branches
+    assert len(branches) > 0
+
+
+def test_get_cached(tmp_path):
+    # Create a temporary directory with a subdirectory containing a dreq.json file
+    version_dir = tmp_path / "v1.0.0"
+    version_dir.mkdir()
+    (version_dir / dc._json_export).touch()
+
+    # Set the _dreq_res variable to the temporary directory
+    dc._dreq_res = str(tmp_path)
+
+    # Test the get_cached function
+    cached_versions = dc.get_cached()
+    assert cached_versions == ["v1.0.0"]
+
+
+def test_retrieve(tmp_path, capfd):
+    "Test the retrieval function."
+    dc._dreq_res = str(tmp_path)
+
+    # Retrieve 'dev' version
+    json_path = dc.retrieve("dev")["dev"]
+    assert os.path.isfile(json_path)
+
+    # Alter on disk (delete first line)
+    with open(json_path) as f:
+        lines = f.read().splitlines(keepends=True)
+    with open(json_path, "w") as f:
+        f.writelines(lines[1:])
+
+    # Make sure it updates
+    json_path = dc.retrieve("dev")["dev"]
+    stdout = capfd.readouterr().out.splitlines()
+    assert len(stdout) == 2
+    assert "Retrieved version 'dev'." in stdout
+    assert "Updated version 'dev'." in stdout
+    # ... and the file was replaced
+    with open(json_path) as f:
+        lines_update = f.read().splitlines(keepends=True)
+    assert lines == lines_update
+
+
+def test_retrieve_with_invalid_version(tmp_path):
+    "Test the retrieval function with an invalid version."
+    dc._dreq_res = str(tmp_path)
+    with pytest.warns(UserWarning, match="Could not retrieve version"):
+        dc.retrieve(" invalid-version ")
+
+
+def test_api_and_html_request():
+    "Test the _send_api_request and _send_html_request functions."
+    tags1 = set(dc._send_api_request(dc.REPO_API_URL, "", "tags"))
+    tags2 = set(dc._send_html_request(dc.REPO_PAGE_URL, "tags"))
+    assert tags1 == tags2
+
+    branches1 = set(dc._send_api_request(dc.REPO_API_URL, "", "branches"))
+    branches2 = set(dc._send_html_request(dc.REPO_PAGE_URL, "branches"))
+    assert branches1 == branches2
+
+
+def test_load(tmp_path):
+    "Test the load function."
+    dc._dreq_res = str(tmp_path)
+
+    with pytest.warns(UserWarning, match="Could not retrieve version"):
+        with pytest.raises(KeyError):
+            jsondict = dc.load(" invalid-version ")
+
+    jsondict = dc.load("dev")
+    assert isinstance(jsondict, dict)
+    assert os.path.isfile(tmp_path / "dev" / dc._json_export)

--- a/sandbox/MS/requirements.txt
+++ b/sandbox/MS/requirements.txt
@@ -1,1 +1,3 @@
 pooch
+requests
+BeautifulSoup4


### PR DESCRIPTION
- Version parsing supports agreed pattern (1.0alpha, 1.0.0, ...)
- `get_versions(local=True)` replaced with `get_cached()`
- `get_versions`: added parameter `target='tags'` (can also be 'branches')
- `get_versions`: added fallback (parsing the regular github repo page) in case the request to the GitHub API fails 
- `retrieve` will update locally cached json files when remote json is from branch and not tag
- `_get_latest_version` now retrieves remote versions if not previously done
- added consolidation function and mapping table in `consolidate_export.py`
- supporting raw and release exports for branches and tags, respectively
- added `kwargs` for a few functions maybe required by developers
- suppressing pooch info output
- updated readme
- added tests