### PR TITLE
Update env.yml with nodefaults channel

### DIFF
--- a/env.yml
+++ b/env.yml
@@ -1,5 +1,6 @@
 channels:
   - conda-forge
+  - nodefaults
 dependencies:
   - ipython
   - pooch


### PR DESCRIPTION
This is a minor change to explicitly exclude the default channel when building a conda environment