### PR TITLE
Allow python before 3.10

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ pip install --upgrade pip
 pip install -r requirements.txt
 ```
 replacing `my_dreq_env_dir` with the path where you wish to store your environment.
-This approach avoids using `conda`, although note that the package currently requires python 3.10 or higher.
+This approach avoids using `conda`.
 
 ### Running the software
 

--- a/data_request_api/stable/query/dreq_classes.py
+++ b/data_request_api/stable/query/dreq_classes.py
@@ -15,7 +15,12 @@ are stored as well, allowing unambiguous comparison with Airtable content.
 '''
 
 from dataclasses import dataclass
-from dataclasses import field as dataclass_field  # "field" is used often for Airtable column names
+from dataclasses import field as dataclass_field  # "field" is used often for Airtable column names, so need a different name here
+
+import sys
+PYTHON_VERSION = (sys.version_info.major, sys.version_info.minor)
+if PYTHON_VERSION < (3,9):
+    from typing import Set
 
 UNIQUE_VAR_NAME = 'compound name'  # method used to uniquely name variables
 
@@ -253,10 +258,19 @@ class expt_request:
     Variable names are stored in seperate sets for different priority levels.
     '''
     experiment : str
-    core : set[str] = dataclass_field(default_factory=set)
-    high : set[str] = dataclass_field(default_factory=set)
-    medium : set[str] = dataclass_field(default_factory=set)
-    low : set[str] = dataclass_field(default_factory=set)
+    if PYTHON_VERSION < (3,9):
+        # Required for python versions before 3.9, see:
+        #   https://stackoverflow.com/questions/75202610/typeerror-type-object-is-not-subscriptable-python
+        # Should remove this if we decide not to support versions before 3.9.
+        core : Set[str] = dataclass_field(default_factory=set)
+        high : Set[str] = dataclass_field(default_factory=set)
+        medium : Set[str] = dataclass_field(default_factory=set)
+        low : Set[str] = dataclass_field(default_factory=set)
+    else:
+        core : set[str] = dataclass_field(default_factory=set)
+        high : set[str] = dataclass_field(default_factory=set)
+        medium : set[str] = dataclass_field(default_factory=set)
+        low : set[str] = dataclass_field(default_factory=set)
 
     def __post_init__(self):
         for p in PRIORITY_LEVELS:

--- a/data_request_api/stable/query/dreq_query.py
+++ b/data_request_api/stable/query/dreq_query.py
@@ -41,15 +41,13 @@ def get_content_type(content):
 
         'version' : 1 base containing the content of a tagged data request version.
     '''
-    match len(content):
-        case 3:
-            content_type = 'working'
-        case 4:
-            content_type = 'working'
-        case 1:
-            content_type = 'version'
-        case _:
-            raise Exception(' * ERROR *    Unable to determine type of data request content in the exported json file')
+    n = len(content)
+    if n in [3,4]:
+        content_type = 'working'
+    elif n == 1:
+        content_type = 'version'
+    else:
+        raise ValueError('Unable to determine type of data request content in the exported json file')
     return content_type
 
 def version_base_name():
@@ -121,13 +119,12 @@ def create_dreq_tables_for_request(content, consolidated=True):
     else:
         # for backward compatibility
         content_type = get_content_type(content)
-        match content_type:
-            case 'working':
-                base_name = 'Data Request Opportunities (Public)'
-            case 'version':
-                base_name = version_base_name()
-            case _:
-                raise Exception('Unknown content type: ' + content_type)
+        if content_type == 'working':
+            base_name = 'Data Request Opportunities (Public)'
+        elif content_type == 'version':
+            base_name = version_base_name()
+        else:
+            raise ValueError('Unknown content type: ' + content_type)
     # base_name = 'Data Request'
     base = content[base_name]
 
@@ -211,13 +208,12 @@ def create_dreq_tables_for_variables(content, consolidated=True):
     else:
         # for backward compatibility
         content_type = get_content_type(content)
-        match content_type:
-            case 'working':
-                base_name = 'Data Request Variables (Public)'
-            case 'version':
-                base_name = version_base_name()
-            case _:
-                raise Exception('Unknown content type: ' + content_type)
+        if content_type == 'working':
+            base_name = 'Data Request Variables (Public)'
+        elif content_type == 'version':
+            base_name = version_base_name()
+        else:
+            raise ValueError('Unknown content type: ' + content_type)
     base = content[base_name]
 
     # Create objects representing data request tables
@@ -296,19 +292,18 @@ def _create_dreq_table_objects(content, working_base='Opportunities'):
 
     # Content is dict loaded from raw airtable export json file
     content_type = get_content_type(content)
-    match content_type:
-        case 'working':
-            match working_base:
-                case 'Opportunities':
-                    base_name = 'Data Request Opportunities (Public)'
-                case 'Variables':
-                    base_name = 'Data Request Variables (Public)'
-                case _:
-                    raise Exception('Which working base to use? Unknown type: ' + working_base)
-        case 'version':
-            base_name = version_base_name()
-        case _:
-            raise Exception('Unknown content type: ' + content_type)
+
+    if content_type == 'working':
+        if working_base == 'Opportunities':
+            base_name = 'Data Request Opportunities (Public)'
+        elif working_base == 'Variables':
+            base_name = 'Data Request Variables (Public)'
+        else:
+            raise ValueError('Which working base to use? Unknown type: ' + working_base)
+    elif content_type == 'version':
+        base_name = version_base_name()
+    else:
+        raise ValueError('Unknown content type: ' + content_type)
     base = content[base_name]
 
     # Get a mapping from table id to table name
@@ -500,12 +495,11 @@ def get_unique_var_name(var):
     -------
     str that uniquely identifes a variable in the data request
     '''
-    match UNIQUE_VAR_NAME:
-        case 'compound name':
-            return var.compound_name
-        case _:
-            raise Exception('How to determine unique variable name?')
-
+    if UNIQUE_VAR_NAME == 'compound name':
+        return var.compound_name
+    else:
+        raise ValueError('Unknown identifier for UNIQUE_VAR_NAME: ' + UNIQUE_VAR_NAME + 
+                         '\nHow should the unique variable name be determined?')
 
 def get_opp_expts(opp, ExptGroups, Expts, verbose=False):
     '''
@@ -756,11 +750,10 @@ def _get_requested_variables(content, use_opp='all', priority_cutoff='Low', verb
         raise TypeError('Input should be dict from raw airtable export json file')
 
     content_type = get_content_type(content)
-    match content_type:
-        case 'working':
-            base_name = 'Data Request Opportunities (Public)'
-        case 'version':
-            base_name = version_base_name()
+    if content_type == 'working':
+        base_name = 'Data Request Opportunities (Public)'
+    elif content_type == 'version':
+        base_name = version_base_name()
 
     tables = content[base_name]
 
@@ -818,11 +811,11 @@ def _get_requested_variables(content, use_opp='all', priority_cutoff='Low', verb
             # Get names of experiments in this experiment group
             for expt_id in expt_group['Experiments']:
 
-                match content_type: # cluge, fix later
-                    case 'working':
-                        expt_table_name = 'Experiment'
-                    case 'version':
-                        expt_table_name = 'Experiments'
+                # cluge
+                if content_type == 'working':
+                    expt_table_name = 'Experiment'
+                elif content_type == 'version':
+                    expt_table_name = 'Experiments'
 
                 expt = tables[expt_table_name]['records'][expt_id]
                 expt_key = expt[' Experiment'].strip()  # Name of experiment, e.g "historical"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ authors = [
 ]
 description = "A programatic interface to the CMIP7 Data Request"
 readme = "README.md"
-requires-python = ">=3.6"
+requires-python = ">=3.8"
 classifiers = [
     "Programming Language :: Python :: 3",
     "License :: OSI Approved :: MIT License",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ authors = [
 ]
 description = "A programatic interface to the CMIP7 Data Request"
 readme = "README.md"
-requires-python = ">=3.10"
+requires-python = ">=3.6"
 classifiers = [
     "Programming Language :: Python :: 3",
     "License :: OSI Approved :: MIT License",


### PR DESCRIPTION
Allow people to run the software using early python versions (though still python 3). This could help people using a venv with an old system python out of their control, as discussed in the TISG meeting today.

Removed the `match` statements in dreq_query.py to allow using python versions < 3.10.
Also needed adjustment to expt_request class definition in dreq_classes.py to use `typing` module, as required for python < 3.9 according to [this post](https://stackoverflow.com/questions/75202610/typeerror-type-object-is-not-subscriptable-python).

Update the README to remove comment about needing python 3.10 or higher.

Verified `workflow_example.py` using venvs for python 3.6.8 and 3.8.3, as well as my usual conda env with python 3.13.1. These envs were all created using the latest requirements.txt / env.yml files, although for the 3.6 one I had to also pip install `dataclasses` (it seems to only be in the standard library from 3.7 onward).

Set the minimum version in `pyproject.toml` to 3.6. This is a little arbitrary, I'm not sure how early a version would be ok (comments welcome). 