### PR TITLE
Add the possibility to specify the config file from environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,7 +165,7 @@ CMIP7_data_request_api_config init
 ```
 
 This will create the `.CMIP7_data_request_api_config` file in your home directory. 
-The default location can be changed using the `CMIP7_DR_API_CONFIGFILE` environment variable.
+Optionally, the default location of this file can be changed by setting the `CMIP7_DR_API_CONFIGFILE` environment variable.
 Alternatively, the file will be automatically created the first time you use the software.
 
 The configuration file is a YAML file containing `key: value` pairs that

--- a/README.md
+++ b/README.md
@@ -164,7 +164,8 @@ After installation, you can initialize the configuration file with the default s
 CMIP7_data_request_api_config init
 ```
 
-This will create the `.CMIP7_data_request_api_config` file in your home directory.
+This will create the `.CMIP7_data_request_api_config` file in your home directory. 
+The default location can be changed using the `CMIP7_DR_API_CONFIGFILE` environment variable.
 Alternatively, the file will be automatically created the first time you use the software.
 
 The configuration file is a YAML file containing `key: value` pairs that

--- a/data_request_api/stable/utilities/config.py
+++ b/data_request_api/stable/utilities/config.py
@@ -2,12 +2,12 @@
 
 
 from pathlib import Path
-
+import os
 import yaml
 
 # Config file location in the user's home directory
 PACKAGE_NAME = "CMIP7_data_request_api"
-CONFIG_FILE = Path.home() / f".{PACKAGE_NAME}_config"
+CONFIG_FILE = os.environ.get("CMIP7_DR_API_CONFIGFILE", Path.home() / f".{PACKAGE_NAME}_config")
 
 # Default config dictionary
 DEFAULT_CONFIG = {


### PR DESCRIPTION
We need this feature in dr2xml.
The idea is to have a single config file for (nearly) everyone which point to a repository where the data request content will be available for using.