### PR TITLE
Minor changes to function calls when writing out variable definitions…

### DIFF
--- a/data_request_api/data_request_api/command_line/export_dreq_lists_json.py
+++ b/data_request_api/data_request_api/command_line/export_dreq_lists_json.py
@@ -149,18 +149,19 @@ def main():
 
         # Get metadata for variables
         all_var_info = dq.get_variables_metadata(
-            base,
+            base, use_dreq_version,
             compound_names=all_var_names,
-            use_dreq_version=use_dreq_version  # TO DEPRECATE
+            #use_dreq_version=use_dreq_version  # TO DEPRECATE
         )
 
         # Write output file(s)
         for filepath in args.variables_metadata:
             dq.write_variables_metadata(
                 all_var_info,
+                use_dreq_version,
                 filepath,
                 api_version=data_request_api.version,
-                use_dreq_version=use_dreq_version,
+                #use_dreq_version=use_dreq_version,
                 content_path=dc._dreq_content_loaded['json_path']
             )
 


### PR DESCRIPTION
Found a minor issue in export_dreq_lists when using the `-vm` option to get variable metadata that isn't covered by the tests.