### PR TITLE
Consolidation v121 and other updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 Python software to interact with the [CMIP7 data request](https://wcrp-cmip.org/cmip7/cmip7-data-request/).
 It provides an API to query and utilize the information in the data request, including example scripts and notebooks showing how to use the API.
 
-For the **Quick Start** guide, please see below.
+Please see below for the [installation guide](#installation) or how to [try it without installation](#try-it-without-installation).
 
 The Data Request Task Team encourages user feedback to help us improve the software.
 Here are some ways to provide feedback:

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 [![pypi](https://img.shields.io/pypi/v/CMIP7-data-request-api.svg)](https://pypi.python.org/pypi/CMIP7-data-request-api)
 [![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/CMIP-Data-Request/CMIP7_DReq_Software/main?filepath=notebooks)
+[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/CMIP-Data-Request/CMIP7_DReq_Software/)
 [![NBviewer](https://raw.githubusercontent.com/jupyter/design/master/logos/Badges/nbviewer_badge.svg)](https://nbviewer.jupyter.org/github/CMIP-Data-Request/CMIP7_DReq_Software/tree/main/notebooks/)
 [![license](https://img.shields.io/github/license/CMIP-Data-Request/CMIP7_DReq_Software.svg)](https://github.com/CMIP-Data-Request/CMIP7_DReq_Software/blob/main/LICENSE)
 [![status](https://www.repostatus.org/badges/latest/active.svg)](https://www.repostatus.org/#active)
@@ -26,6 +27,14 @@ Please note that a technical update to the Data Request, `v1.2.1`, is planned fo
 This update will affect some details such as the names of CMOR variables, without substantially changing the scientific content of the request.
 For further information please see the [v1.2 release page](https://wcrp-cmip.org/cmip7-data-request-v1-2/).
 An update of this software will follow the release of `v1.2.1`.
+
+
+## Try It Without Installation
+
+You can launch and interact with this repository in a live environment via [Binder](https://mybinder.org/) or [Google Colab](https://colab.research.google.com/) — no installation needed, just click on one of the badges to run it in your browser:
+
+[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/CMIP-Data-Request/CMIP7_DReq_Software/main?filepath=notebooks)
+[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/CMIP-Data-Request/CMIP7_DReq_Software/)
 
 
 ## Installation

--- a/binder/environment.yml
+++ b/binder/environment.yml
@@ -1,0 +1,13 @@
+channels:
+  - conda-forge
+  - nodefaults
+dependencies:
+  - bs4
+  - coverage
+  - openpyxl
+  - pooch
+  - pytest
+  - pyyaml
+  - requests
+  - pip:
+    - CMIP7-data-request-api

--- a/data_request_api/data_request_api/command_line/config.py
+++ b/data_request_api/data_request_api/command_line/config.py
@@ -38,7 +38,7 @@ Examples:
         dreqcfg.CONFIG_FILE = args.cfgfile
 
     if len(args.command) == 0 or args.command[0] == "init":
-        print("Initializing config file:")
+        print(f"Initializing config file: '{dreqcfg.CONFIG_FILE}'")
         dreqcfg.load_config()
     elif args.command[0] == "reset":
         print("Resetting config with defaults:")

--- a/data_request_api/data_request_api/command_line/estimate_dreq_volume.py
+++ b/data_request_api/data_request_api/command_line/estimate_dreq_volume.py
@@ -172,7 +172,7 @@ years: 1
     warning_msg += '\n They should be used with caution and verified against known data volumes.\n'
 
     request_from_input_file = None
-    if os.path.exists(args.request):
+    if os.path.isfile(args.request):
         # Argument is a file that lists requested variables
         filepath = args.request
         with open(filepath, 'r') as f:

--- a/data_request_api/data_request_api/content/consolidate_export.py
+++ b/data_request_api/data_request_api/content/consolidate_export.py
@@ -122,7 +122,7 @@ def _apply_hard_fixes(data):
     return data
 
 
-def _filter_references(val, key, table, rid):
+def _filter_references(val, key, table, rid, dtype=None):
     """
     Filters lists of or strings with comma-separated references to other records.
     """
@@ -142,7 +142,7 @@ def _filter_references(val, key, table, rid):
                     f"'{table}': Filtered {len(val) - len(filtered)} of {len(val)}"
                     f" references for '{key}' of record '{rid}'."
                 )
-        return filtered
+        return _fix_dtype(key, filtered, dtype)
     elif isinstance(val, str) and val.startswith("rec"):
         if "," in val:
             vallist = [v.strip() for v in val.split(",")]
@@ -157,14 +157,14 @@ def _filter_references(val, key, table, rid):
                         f"'{table}': Filtered {len(vallist) - len(filtered)} of"
                         f" {len(vallist)} references for '{key}' of record '{rid}'."
                     )
-            return ",".join(filtered)
+            return _fix_dtype(key, ",".join(filtered), dtype)
         elif val.strip() in filtered_records:
             logger.warning(f"'{table}': Filtered the only reference for '{key}' of record '{rid}'.")
-            return ""
+            return _fix_dtype(key, "", dtype)
         else:
-            return _fix_str(val)
+            return _fix_dtype(key, _fix_str(val), dtype)
     else:
-        return _fix_str(val)
+        return _fix_dtype(key, _fix_str(val), dtype)
 
 
 def _gen_rid_uid_map(data):
@@ -209,6 +209,44 @@ def _fix_str_nested(data):
     for table in data.values():
         for record in table["records"].values():
             record.update({k: sub(pattern, ", ", v).strip() if isinstance(v, str) else v for k, v in record.items()})
+
+
+def _fix_dtype(fkey, fval, dtype=None):
+    """Fixes data types for record fields."""
+    logger = get_logger()
+
+    if dtype is None:
+        return fval
+    elif dtype == "str":
+        logger.debug(f"Consolidate export: Converting field '{fkey}' ('{fval}') to string.")
+        return str(fval)
+    elif dtype == "int":
+        logger.debug(f"Consolidate export: Converting field '{fkey}' ('{fval}') to int.")
+        return int(fval)
+    elif dtype == "float":
+        logger.debug(f"Consolidate export: Converting field '{fkey}' ('{fval}') to float.")
+        return float(fval)
+    elif dtype == "listofstr":
+        logger.debug(f"Consolidate export: Converting field '{fkey}' to a list of strings.")
+        if isinstance(fval, list):
+            return [str(v) for v in fval]
+        else:
+            return [str(fval)]
+    elif dtype == "listofint":
+        logger.debug(f"Consolidate export: Converting field '{fkey}' to a list of ints.")
+        if isinstance(fval, list):
+            return [int(v) for v in fval]
+        else:
+            return [int(fval)]
+    elif dtype == "listoffloat":
+        logger.debug(f"Consolidate export: Converting field '{fkey}' to a list of floats.")
+        if isinstance(fval, list):
+            return [float(v) for v in fval]
+        else:
+            return [float(fval)]
+    else:
+        logger.warning(f"Consolidate export: Unsupported data type '{dtype}' for field '{fkey}'.")
+        return fval
 
 
 def map_data(data, mapping_table, version, **kwargs):
@@ -327,7 +365,11 @@ def map_data(data, mapping_table, version, **kwargs):
                     "records": {
                         record_id: {
                             mapinfo["internal_consistency"].get(reckey, reckey): _filter_references(
-                                recvalue, reckey, table, record_id
+                                recvalue,
+                                reckey,
+                                table,
+                                record_id,
+                                mapinfo["field_dtypes"].get(mapinfo["internal_consistency"].get(reckey, reckey), None),
                             )
                             for reckey, recvalue in record.items()
                             if reckey not in mapinfo["drop_keys"]
@@ -542,6 +584,8 @@ def map_data(data, mapping_table, version, **kwargs):
         # Consistency fixes
         mapped_data = next(iter(data.values()))
         mapped_data = _apply_consistency_fixes(mapped_data)
+        # String fixes
+        logger.debug("Consolidation: Removing / Adding (un)necessary whitespace to strings.")
         _fix_str_nested(mapped_data)
         mapped_data["version"] = version
         return {"Data Request": mapped_data}

--- a/data_request_api/data_request_api/content/mapping_table.py
+++ b/data_request_api/data_request_api/content/mapping_table.py
@@ -59,6 +59,9 @@ Internal renaming of keys to achieve consistency across content versions ("inter
 Attributes to remove ("drop_keys"):
     List of record attributes that are not needed in the one-base (=release) structure.
 
+Data type of record attributes ("field_dtypes"):
+    Dictionary of field names and their data type. This is required as some attributes differ between export
+    types, such as integer fields in one export type being stored as strings in the other.
 
 
 Example Configuration
@@ -86,6 +89,14 @@ mapping_table = {
                 },
                 "internal_consistency": {"OldFieldName": "NewFieldName"},
                 "drop_keys": ["Field1", "Field2"],
+                "field_dtypes": {
+                    "Field1": "str",
+                    "Field2": "int",
+                    "Field3": "float",
+                    "Field4": "listofstr",
+                    "Field5": "listofint",
+                    "Field6": "listoffloat",
+                },
       },
 }
 """
@@ -111,6 +122,7 @@ mapping_table = {
             "name": "Name",
             "Physical parameters 2": "Physical parameters",
         },
+        "field_dtypes": {},
     },
     "CMIP6 Table Identifiers (legacy)": {
         "source_base": "Data Request Variables (Public)",
@@ -124,6 +136,7 @@ mapping_table = {
         "internal_consistency": {
             "Comment": "Notes",
         },
+        "field_dtypes": {},
     },
     "CMIP6 Frequency (legacy)": {
         "source_base": "Data Request Variables (Public)",
@@ -132,6 +145,7 @@ mapping_table = {
         "internal_filters": {},
         "drop_keys": [],
         "internal_consistency": {},
+        "field_dtypes": {},
     },
     "CMIP7 Frequency": {
         "source_base": "Data Request Variables (Public)",
@@ -142,6 +156,7 @@ mapping_table = {
         "internal_consistency": {
             "CMIP6 Frequency": "CMIP6 Frequency (legacy)",
         },
+        "field_dtypes": {},
     },
     "Cell Measures": {
         "source_base": "Data Request Variables (Public)",
@@ -150,6 +165,7 @@ mapping_table = {
         "internal_filters": {},
         "drop_keys": ["Variables comments"],
         "internal_consistency": {},
+        "field_dtypes": {},
     },
     "Cell Methods": {
         "source_base": "Data Request Variables (Public)",
@@ -165,6 +181,7 @@ mapping_table = {
             "Structures",
         ],
         "internal_consistency": {"uid": "UID"},
+        "field_dtypes": {},
     },
     "Coordinates and Dimensions": {
         "source_base": "Data Request Variables (Public)",
@@ -186,6 +203,7 @@ mapping_table = {
             "Spatial shape": "Spatial Shape",
             "Temporal shape": "Temporal Shape",
         },
+        "field_dtypes": {},
     },
     "Data Request Themes": {
         "source_base": "Data Request Opportunities (Public)",
@@ -197,6 +215,7 @@ mapping_table = {
             "Opportunities led": "Lead theme for Opportunity",
             "Opportunity": "Tagged for Opportunity",
         },
+        "field_dtypes": {},
     },
     "Docs for Opportunities": {
         "source_base": "Data Request Opportunities (Public)",
@@ -205,6 +224,7 @@ mapping_table = {
         "internal_filters": {},
         "drop_keys": ["Base"],
         "internal_consistency": {"language identifier": "Language Identifier"},
+        "field_dtypes": {},
     },
     "ESM-BCV 1.4": {
         "source_base": "Data Request Variables (Public)",
@@ -238,6 +258,9 @@ mapping_table = {
             "Title (from CMOR Variables)": "Title (from Variables)",
             "Units": "Units (from Physical Parameter) (from Variables)",
         },
+        "field_dtypes": {
+            "Title (from Variables)": "listofstr",
+        },
     },
     "Experiment Group": {
         "source_base": "Data Request Opportunities (Public)",
@@ -265,6 +288,7 @@ mapping_table = {
             "Themes to alert",
         ],
         "internal_consistency": {},
+        "field_dtypes": {},
     },
     "Experiments": {
         "source_base": "Data Request Opportunities (Public)",
@@ -284,6 +308,7 @@ mapping_table = {
         "internal_consistency": {
             "Unique list of variables attached to Opportunity (linked) (from Opportunity)": ("Variables")
         },
+        "field_dtypes": {},
     },
     "Glossary": {
         "source_base": "Data Request Opportunities (Public)",
@@ -292,6 +317,7 @@ mapping_table = {
         "internal_filters": {},
         "drop_keys": ["Opportunity"],
         "internal_consistency": {},
+        "field_dtypes": {},
     },
     "MIPs": {
         "source_base": "Data Request Opportunities (Public)",
@@ -300,6 +326,7 @@ mapping_table = {
         "internal_filters": {},
         "drop_keys": [],
         "internal_consistency": {},
+        "field_dtypes": {},
     },
     "Modelling Realm": {
         "source_base": "Data Request Variables (Public)",
@@ -310,6 +337,7 @@ mapping_table = {
         "internal_consistency": {
             "Variables": "Variables - primary realm",
         },
+        "field_dtypes": {},
     },
     "Opportunity": {
         "source_base": "Data Request Opportunities (Public)",
@@ -352,6 +380,7 @@ mapping_table = {
             ),
             "Working/Updated Variable Groups": "Variable Groups",
         },
+        "field_dtypes": {},
     },
     "Physical Parameters": {
         "source_base": "Data Request Physical Parameters (Public)",
@@ -389,6 +418,7 @@ mapping_table = {
             "Tagged author team",
         ],
         "internal_consistency": {},
+        "field_dtypes": {},
     },
     "Priority Level": {
         "source_base": "Data Request Opportunities (Public)",
@@ -397,6 +427,7 @@ mapping_table = {
         "internal_filters": {},
         "drop_keys": [],
         "internal_consistency": {},
+        "field_dtypes": {},
     },
     "Ranking": {
         "source_base": "Data Request Variables (Public)",
@@ -405,6 +436,7 @@ mapping_table = {
         "internal_filters": {},
         "drop_keys": [],
         "internal_consistency": {"Name": "ID"},
+        "field_dtypes": {},
     },
     "Spatial Shape": {
         "source_base": "Data Request Variables (Public)",
@@ -413,6 +445,7 @@ mapping_table = {
         "internal_filters": {},
         "drop_keys": ["Comments", "Structure"],
         "internal_consistency": {},
+        "field_dtypes": {},
     },
     "Temporal Shape": {
         "source_base": "Data Request Variables (Public)",
@@ -421,6 +454,7 @@ mapping_table = {
         "internal_filters": {},
         "drop_keys": ["Comments", "Structure"],
         "internal_consistency": {},
+        "field_dtypes": {},
     },
     "Time Subset": {
         "source_base": "Data Request Opportunities (Public)",
@@ -433,6 +467,7 @@ mapping_table = {
             "sliceLenUnit": "subsetLenUnit",
             "uid": "UID",
         },
+        "field_dtypes": {},
     },
     "Variable Group": {
         "source_base": "Data Request Opportunities (Public)",
@@ -486,19 +521,12 @@ mapping_table = {
             "Experiment Groups (from Final Opportunity selection)": "Experiment Groups (from Opportunity)",
             "Final Opportunity selection": "Opportunity",
         },
+        "field_dtypes": {},
     },
     "Variables": {
         "source_base": "Data Request Variables (Public)",
         "source_table": ["Variable", "Variables"],
         "internal_mapping": {
-            "ESM-BCV 1.4": {
-                "base_copy_of_table": False,
-                "base": "Data Request Variables (Public)",
-                "table": "ESM-BCV 1.4",
-                "operation": "split",
-                "map_by_key": ["Name"],
-                "entry_type": "name",
-            },
             "CMIP7 Variable Groups": {
                 "base_copy_of_table": False,
                 "base": "Data Request Opportunities (Public)",
@@ -593,6 +621,12 @@ mapping_table = {
             "Status": "Variable Status",
             "Status (from Physical Parameter)": "Physical Parameter Status",
             "Table": "CMIP6 Table (legacy)",
+        },
+        "field_dtypes": {
+            "Vertical Dimension": "int",
+            "Horizontal Mesh": "int",
+            "Temporal Sampling Rate": "int",
+            "Min Rank in CMIP6 download statistics": "listofint",
         },
     },
 }

--- a/data_request_api/data_request_api/content/mapping_table.py
+++ b/data_request_api/data_request_api/content/mapping_table.py
@@ -95,8 +95,18 @@ mapping_table = {
         "source_base": "Data Request Physical Parameters (Public)",
         "source_table": ["CF Standard Names", "CF Standard Name"],
         "internal_mapping": {},
-        "internal_filters": {},
-        "drop_keys": ["Comments"],
+        "internal_filters": {
+            "Physical parameters": {
+                "aliases": [],
+                "operator": "nonempty",
+            },
+            "Status (from Physical parameters)": {
+                "aliases": [],
+                "operator": "in",
+                "values": ["New", "Existing physical parameter"],
+            },
+        },
+        "drop_keys": ["Comments", "Status (from Physical parameters)"],
         "internal_consistency": {
             "name": "Name",
             "Physical parameters 2": "Physical parameters",
@@ -356,12 +366,13 @@ mapping_table = {
                 "entry_type": "name",
             }
         },
-        "internal_filters": {},
-        # "Opportunity Status (from CMIP7 Variable Groups) (from Variables) (from Link to back sync)": {
-        #    "aliases": [],
-        #    "operator": "in",
-        #    "values": ["Under review", "Accepted"],
-        # },
+        "internal_filters": {
+            "Status": {
+                "aliases": [],
+                "operator": "in",
+                "values": ["New", "Existing physical parameter"],
+            },
+        },
         "drop_keys": [
             "Atmosphere review comments",
             "Atmosphere team review status",

--- a/data_request_api/data_request_api/tests/test_cli.py
+++ b/data_request_api/data_request_api/tests/test_cli.py
@@ -428,7 +428,7 @@ class TestEstimateDreqVolume:
             yaml.dump(config, fh)
         dc.load("v1.2")
 
-    def test_esimate_dreq_volume(self, temp_config_file, consolidate):
+    def test_estimate_dreq_volume(self, temp_config_file, consolidate):
         os.chdir(temp_config_file.parent)
         ofile = temp_config_file.parent / "test1.json"
         sizecfg = temp_config_file.parent / "size.yaml"

--- a/data_request_api/data_request_api/tests/test_cli.py
+++ b/data_request_api/data_request_api/tests/test_cli.py
@@ -4,10 +4,9 @@ import subprocess
 import sys
 from pathlib import Path
 
+import data_request_api.content.dreq_content as dc
 import pytest
 import yaml
-
-import data_request_api.content.dreq_content as dc
 
 
 @pytest.fixture(scope="class")
@@ -72,9 +71,7 @@ class TestExportDreqListsJson:
         assert result.returncode == 0
         assert os.path.exists(ofile) and os.path.getsize(ofile) > 0
 
-    def test_export_dreq_lists_json_with_opportunities_file(
-        self, temp_config_file, consolidate
-    ):
+    def test_export_dreq_lists_json_with_opportunities_file(self, temp_config_file, consolidate):
         # Test that the script creates an opportunities file template
         opportunities_file = temp_config_file.parent / "opportunities.json"
         opportunities_file.unlink(missing_ok=True)
@@ -94,10 +91,7 @@ class TestExportDreqListsJson:
             text=True,
         )
         assert result.returncode == 0
-        assert (
-            os.path.exists(opportunities_file)
-            and os.path.getsize(opportunities_file) > 0
-        )
+        assert os.path.exists(opportunities_file) and os.path.getsize(opportunities_file) > 0
         assert not os.path.exists(ofile) or os.path.getsize(ofile) == 0
 
         # Test that it now applies the opportunities settings from opportunities_file
@@ -117,13 +111,9 @@ class TestExportDreqListsJson:
         assert result.returncode == 0
         assert os.path.exists(ofile) and os.path.getsize(ofile) > 0
 
-    def test_export_dreq_lists_json_with_invalid_opportunities_file(
-        self, temp_config_file, consolidate
-    ):
+    def test_export_dreq_lists_json_with_invalid_opportunities_file(self, temp_config_file, consolidate):
         # Test that the script raises an error with an invalid opportunities file
-        opportunities_file = (
-            temp_config_file.parent / "invalid_opportunities.json"
-        )
+        opportunities_file = temp_config_file.parent / "invalid_opportunities.json"
         opportunities_file.unlink(missing_ok=True)
         ofile = temp_config_file.parent / "test3.json"
         ofile.unlink(missing_ok=True)
@@ -145,9 +135,7 @@ class TestExportDreqListsJson:
         assert result.returncode != 0
         assert not os.path.exists(ofile) or os.path.getsize(ofile) == 0
 
-    def test_export_dreq_lists_json_entry_point(
-        self, temp_config_file, consolidate
-    ):
+    def test_export_dreq_lists_json_entry_point(self, temp_config_file, consolidate):
         ofile = temp_config_file.parent / "test4.json"
         ofile.unlink(missing_ok=True)
         result = subprocess.run(
@@ -202,9 +190,7 @@ class TestGetVariablesMetadata:
         assert result.returncode == 0
         assert os.path.exists(ofile) and os.path.getsize(ofile) > 0
 
-    def test_get_variables_metadata_with_compound_names(
-        self, temp_config_file, consolidate
-    ):
+    def test_get_variables_metadata_with_compound_names(self, temp_config_file, consolidate):
         ofile = temp_config_file.parent / "test2.json"
         ofile.unlink(missing_ok=True)
         result = subprocess.run(
@@ -225,9 +211,7 @@ class TestGetVariablesMetadata:
         assert result.returncode == 0
         assert os.path.exists(ofile) and os.path.getsize(ofile) > 0
 
-    def test_get_variables_metadata_with_cmor_tables(
-        self, temp_config_file, consolidate
-    ):
+    def test_get_variables_metadata_with_cmor_tables(self, temp_config_file, consolidate):
         ofile = temp_config_file.parent / "test3.json"
         ofile.unlink(missing_ok=True)
         result = subprocess.run(
@@ -248,9 +232,7 @@ class TestGetVariablesMetadata:
         assert result.returncode == 0
         assert os.path.exists(ofile) and os.path.getsize(ofile) > 0
 
-    def test_get_variables_metadata_with_cmor_variables(
-        self, temp_config_file, consolidate
-    ):
+    def test_get_variables_metadata_with_cmor_variables(self, temp_config_file, consolidate):
         ofile = temp_config_file.parent / "test4.json"
         ofile.unlink(missing_ok=True)
         result = subprocess.run(
@@ -271,9 +253,7 @@ class TestGetVariablesMetadata:
         assert result.returncode == 0
         assert os.path.exists(ofile) and os.path.getsize(ofile) > 0
 
-    def test_get_variables_metadata_entry_point(
-        self, temp_config_file, consolidate
-    ):
+    def test_get_variables_metadata_entry_point(self, temp_config_file, consolidate):
         ofile = temp_config_file.parent / "test5.json"
         ofile.unlink(missing_ok=True)
         result = subprocess.run(
@@ -288,3 +268,234 @@ class TestGetVariablesMetadata:
         )
         assert result.returncode == 0
         assert os.path.exists(ofile) and os.path.getsize(ofile) > 0
+
+
+@pytest.mark.parametrize(
+    "consolidate",
+    ["consolidate", "no consolidate"],
+    indirect=True,
+    scope="class",
+)
+class TestCompareVariables:
+    @pytest.fixture(scope="class", autouse=True)
+    def setup_class(self, request):
+        # Initialize config and load v1.2 content version
+        self.temp_config_file = request.getfixturevalue("temp_config_file")
+        self.consolidate = request.getfixturevalue("consolidate")
+        with open(self.temp_config_file, "w") as fh:
+            config = {
+                "consolidate": self.consolidate == "consolidate",
+                "cache_dir": str(self.temp_config_file.parent),
+            }
+            yaml.dump(config, fh)
+        dc.load("v1.2")
+        dc.load("v1.2.1")
+
+    def test_compare_variables(self, temp_config_file, consolidate):
+        os.chdir(temp_config_file.parent)
+        ofileA = temp_config_file.parent / "testA.json"
+        ofileB = temp_config_file.parent / "testB.json"
+        ofile_vars = temp_config_file.parent / "diffs_by_variable.json"
+        ofile_attr = temp_config_file.parent / "diffs_by_attribute.json"
+        ofile_missing = temp_config_file.parent / "missing_variables.json"
+        attr_file = temp_config_file.parent / "attributes.yaml"
+
+        # Part 1 - Standard comparison
+        ofile_vars.unlink(missing_ok=True)
+        ofile_attr.unlink(missing_ok=True)
+        ofile_missing.unlink(missing_ok=True)
+        ofileA.unlink(missing_ok=True)
+        ofileB.unlink(missing_ok=True)
+        attr_file.unlink(missing_ok=True)
+        # Create Variable List A
+        result = subprocess.run(
+            [
+                sys.executable,
+                "-m",
+                "data_request_api.command_line.get_variables_metadata",
+                "v1.2",
+                "-o",
+                ofileA,
+            ],
+            capture_output=True,
+            text=True,
+        )
+        assert result.returncode == 0
+        assert os.path.exists(ofileA) and os.path.getsize(ofileA) > 0
+        # Create Variable List B
+        result = subprocess.run(
+            [
+                sys.executable,
+                "-m",
+                "data_request_api.command_line.get_variables_metadata",
+                "v1.2.1",
+                "-o",
+                ofileB,
+            ],
+            capture_output=True,
+            text=True,
+        )
+        assert result.returncode == 0
+        assert os.path.exists(ofileB) and os.path.getsize(ofileB) > 0
+        # Actual comparison
+        result = subprocess.run(
+            [
+                sys.executable,
+                "-m",
+                "data_request_api.command_line.compare_variables",
+                ofileA,
+                ofileB,
+            ],
+            capture_output=True,
+            text=True,
+        )
+        assert result.returncode == 0
+        assert os.path.exists(ofile_missing) and os.path.getsize(ofile_missing) > 0
+        assert os.path.exists(ofile_vars) and os.path.getsize(ofile_vars) > 0
+        assert os.path.exists(ofile_attr) and os.path.getsize(ofile_attr) > 0
+        assert os.path.exists(attr_file) and os.path.getsize(attr_file) > 0
+
+        # Part 2 - Provide attribute file
+        ofile_vars.unlink(missing_ok=True)
+        ofile_attr.unlink(missing_ok=True)
+        ofile_missing.unlink(missing_ok=True)
+        # Write custom attributes file
+        cattr_file = temp_config_file.parent / "custom_attrs.yaml"
+        cattr_file.unlink(missing_ok=True)
+        config = {
+            "compare_attributes": ["standard_name", "units", "cell_methods"],
+            "repos": {
+                "cmip6": {
+                    "url": "https://github.com/PCMDI/cmip6-cmor-tables",
+                }
+            },
+        }
+        with open(cattr_file, "w") as f:
+            yaml.dump(config, f, default_flow_style=False)
+        # Actual comparison
+        result = subprocess.run(
+            [
+                sys.executable,
+                "-m",
+                "data_request_api.command_line.compare_variables",
+                ofileA,
+                ofileB,
+                "-c",
+                cattr_file,
+            ],
+            capture_output=True,
+            text=True,
+        )
+        assert result.returncode == 0
+        assert os.path.exists(ofile_missing) and os.path.getsize(ofile_missing) > 0
+        assert os.path.exists(ofile_vars) and os.path.getsize(ofile_vars) > 0
+        assert os.path.exists(ofile_attr) and os.path.getsize(ofile_attr) > 0
+        assert os.path.getsize(cattr_file) < os.path.getsize(attr_file)
+
+        # Part 3 - Compare with CMIP6
+        ofile_vars.unlink(missing_ok=True)
+        ofile_attr.unlink(missing_ok=True)
+        ofile_missing.unlink(missing_ok=True)
+        # Actual comparison
+        result = subprocess.run(
+            [sys.executable, "-m", "data_request_api.command_line.compare_variables", ofileB, "cmip6"],
+            capture_output=True,
+            text=True,
+        )
+        assert result.returncode == 0
+        assert os.path.exists(ofile_missing) and os.path.getsize(ofile_missing) > 0
+        assert os.path.exists(ofile_vars) and os.path.getsize(ofile_vars) > 0
+        assert os.path.exists(ofile_attr) and os.path.getsize(ofile_attr) > 0
+
+
+@pytest.mark.parametrize(
+    "consolidate",
+    ["consolidate", "no consolidate"],
+    indirect=True,
+    scope="class",
+)
+class TestEstimateDreqVolume:
+    @pytest.fixture(scope="class", autouse=True)
+    def setup_class(self, request):
+        # Initialize config and load v1.2 content version
+        self.temp_config_file = request.getfixturevalue("temp_config_file")
+        self.consolidate = request.getfixturevalue("consolidate")
+        with open(self.temp_config_file, "w") as fh:
+            config = {
+                "consolidate": self.consolidate == "consolidate",
+                "cache_dir": str(self.temp_config_file.parent),
+            }
+            yaml.dump(config, fh)
+        dc.load("v1.2")
+
+    def test_esimate_dreq_volume(self, temp_config_file, consolidate):
+        os.chdir(temp_config_file.parent)
+        ofile = temp_config_file.parent / "test1.json"
+        sizecfg = temp_config_file.parent / "size.yaml"
+        ofile.unlink(missing_ok=True)
+        sizecfg.unlink(missing_ok=True)
+        # Part 1 - Create size.yaml
+        result = subprocess.run(
+            [
+                sys.executable,
+                "-m",
+                "data_request_api.command_line.estimate_dreq_volume",
+                "v1.2",
+                "-o",
+                ofile,
+            ],
+            capture_output=True,
+            text=True,
+        )
+        assert result.returncode == 0
+        assert not os.path.exists(ofile) or os.path.getsize(ofile) == 0
+        assert os.path.exists(sizecfg) and os.path.getsize(sizecfg) > 0
+        # Part 2 - Actual volume estimate
+        result = subprocess.run(
+            [
+                sys.executable,
+                "-m",
+                "data_request_api.command_line.estimate_dreq_volume",
+                "v1.2",
+                "-o",
+                ofile,
+            ],
+            capture_output=True,
+            text=True,
+        )
+        assert result.returncode == 0
+        assert os.path.exists(ofile) and os.path.getsize(ofile) > 0
+        assert os.path.exists(sizecfg) and os.path.getsize(sizecfg) > 0
+        # Part 3 - Custom size.yaml
+        ofile.unlink(missing_ok=True)
+        csizecfg = temp_config_file.parent / "custom_size.yaml"
+        csizecfg.unlink(missing_ok=True)
+        # Read default size.yaml
+        with open(sizecfg) as fh:
+            config = yaml.safe_load(fh)
+        sizecfg.unlink(missing_ok=True)
+        # Update config
+        config["longitude"] = 720
+        config["latitude"] = 360
+        # Write custom size.yaml
+        with open(csizecfg, "w") as fh:
+            yaml.dump(config, fh)
+        # Actual volume estimate
+        result = subprocess.run(
+            [
+                sys.executable,
+                "-m",
+                "data_request_api.command_line.estimate_dreq_volume",
+                "v1.2",
+                "-o",
+                ofile,
+                "-c",
+                csizecfg,
+            ],
+            capture_output=True,
+            text=True,
+        )
+        assert result.returncode == 0
+        assert os.path.exists(ofile) and os.path.getsize(ofile) > 0
+        assert os.path.exists(csizecfg) and os.path.getsize(csizecfg) > 0
+        assert not os.path.exists(sizecfg) or os.path.getsize(sizecfg) == 0

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,4 +5,3 @@ pooch
 pytest
 pyyaml
 requests
-pyyaml

--- a/scripts/check_consolidation.py
+++ b/scripts/check_consolidation.py
@@ -24,7 +24,13 @@ offlineREL = version in dc.get_cached(export="release")
 
 rel = dc.load(version, export="release", consolidate=True, offline=offlineREL)
 rel["Data Request"].pop("version")
-raw = dc.load(version, export="raw", consolidate=True, offline=offlineRAW, force=True)
+raw = dc.load(
+    version,
+    export="raw",
+    consolidate=True,
+    offline=offlineRAW,
+    force_consolidate=True,
+)
 raw["Data Request"].pop("version")
 
 print()
@@ -32,7 +38,7 @@ print()
 print()
 print("#-" * 25)
 print("#-" + " " * 45 + "-#-")
-print(f"#-    Consolidation check results for {version}:    -#-")
+print(f"#- Consolidation check results for '{version}':")
 print("#-" + " " * 45 + "-#-")
 print("#-" * 25)
 print()

--- a/scripts/check_consolidation2.py
+++ b/scripts/check_consolidation2.py
@@ -84,7 +84,13 @@ if long_summary:
     if code:
         print()
     print(f"{code}")
-dreqraw = dc.load(version, export="raw", consolidate=True, offline=offlineRAW)
+dreqraw = dc.load(
+    version,
+    export="raw",
+    consolidate=True,
+    offline=offlineRAW,
+    force_consolidate=True,
+)
 if long_summary:
     print(f"{code}")
     if code:
@@ -106,7 +112,9 @@ if long_summary:
     if code:
         print()
     print(f"{code}")
-dreqrel = dc.load(version, export="release", consolidate=True, offline=offlineREL)
+dreqrel = dc.load(
+    version, export="release", consolidate=True, offline=offlineREL
+)
 if long_summary:
     print(f"{code}")
     if code:
@@ -121,16 +129,18 @@ def compare_dicts(raw, rel):
     rid_uid_map_raw = ce._gen_rid_uid_map(raw["Data Request"])
     rid_uid_map_rel = ce._gen_rid_uid_map(rel["Data Request"])
     print(f"- {len(ce.filtered_records)} filtered records")
-    print(f"- {len(rid_uid_map_raw.keys())} rid->UID mapping entries (raw export)")
-    print(f"- {len(rid_uid_map_rel.keys())} rid->UID mapping entries (release export)")
+    print(
+        f"- {len(rid_uid_map_raw.keys())} rid->UID mapping entries (raw export)"
+    )
+    print(
+        f"- {len(rid_uid_map_rel.keys())} rid->UID mapping entries (release export)"
+    )
     print()
 
     if len(raw["Data Request"].keys()) != len(rel["Data Request"].keys()):
         print("ERROR: Different number of tables")
-        return False
     if raw["Data Request"]["version"] != rel["Data Request"]["version"]:
         print("ERROR: Differing versions")
-        return False
 
     # Clear version
     version = raw["Data Request"].pop("version")
@@ -141,9 +151,13 @@ def compare_dicts(raw, rel):
     matches_uid = defaultdict(lambda: defaultdict())
     examples = defaultdict(lambda: defaultdict())
     diff_fields_count = defaultdict(lambda: defaultdict(int))
-    diff_string_count = defaultdict(lambda: defaultdict(lambda: defaultdict(int)))
+    diff_string_count = defaultdict(
+        lambda: defaultdict(lambda: defaultdict(int))
+    )
     diff_rec_count = defaultdict(lambda: defaultdict(lambda: defaultdict(int)))
-    diff_rec = defaultdict(lambda: defaultdict(lambda: defaultdict(lambda: defaultdict(list))))
+    diff_rec = defaultdict(
+        lambda: defaultdict(lambda: defaultdict(lambda: defaultdict(list)))
+    )
 
     # Comparison for each table and field and record
     for table_i in raw["Data Request"]:
@@ -155,7 +169,9 @@ def compare_dicts(raw, rel):
         print("-" * 50)
         print()
         if table_i not in rel["Data Request"]:
-            print(f"ERROR: '{table_i}' is missing or named differently in release export")
+            print(
+                f"ERROR: '{table_i}' is missing or named differently in release export"
+            )
             continue
 
         # Compare table definition
@@ -176,7 +192,8 @@ def compare_dicts(raw, rel):
             relid = [
                 rid
                 for rid in rel["Data Request"][table_i]["records"].keys()
-                if rel["Data Request"][table_i]["records"][rid]["UID"] == rawrec["UID"]
+                if rel["Data Request"][table_i]["records"][rid]["UID"]
+                == rawrec["UID"]
             ]
             if len(relid) == 0:
                 nomatch[table_i].append(rawrec["UID"])
@@ -205,30 +222,50 @@ def compare_dicts(raw, rel):
                     if rawrec[fld]:
                         match = False
                         fmatch = False
-                        if isinstance(rawrec[fld], list) and any([item.startswith("rec") for item in rawrec[fld]]):
+                        if isinstance(rawrec[fld], list) and any(
+                            [item.startswith("rec") for item in rawrec[fld]]
+                        ):
                             diff_rec_count[table_i][fld]["rawmore"] += 1
                             diff_rec_count[table_i][fld]["rawmoreuids"] += 1
-                            rawuids = {rid_uid_map_raw[ridx] for ridx in rawrec[fld]}
-                            diff_rec[table_i][fld]["raw"][rawrec["UID"]] = list(rawuids)
+                            rawuids = {
+                                rid_uid_map_raw[ridx] for ridx in rawrec[fld]
+                            }
+                            diff_rec[table_i][fld]["raw"][rawrec["UID"]] = list(
+                                rawuids
+                            )
                     else:
                         continue
                 elif fld not in rawrec.keys():
                     if relrec[fld]:
                         match = False
                         fmatch = False
-                        if isinstance(relrec[fld], list) and any([item.startswith("rec") for item in relrec[fld]]):
+                        if isinstance(relrec[fld], list) and any(
+                            [item.startswith("rec") for item in relrec[fld]]
+                        ):
                             diff_rec_count[table_i][fld]["relmore"] += 1
                             diff_rec_count[table_i][fld]["relmoreuids"] += 1
-                            reluids = {rid_uid_map_rel[ridx] for ridx in relrec[fld]}
-                            diff_rec[table_i][fld]["rel"][relrec["UID"]] = list(reluids)
+                            reluids = {
+                                rid_uid_map_rel[ridx] for ridx in relrec[fld]
+                            }
+                            diff_rec[table_i][fld]["rel"][relrec["UID"]] = list(
+                                reluids
+                            )
                     else:
                         continue
                 elif not rawrec[fld] and not relrec[fld]:
                     continue
-                elif not isinstance(rawrec[fld], type(relrec[fld])) and (rawrec[fld] or relrec[fld]):
+                elif not isinstance(rawrec[fld], type(relrec[fld])) and (
+                    rawrec[fld] or relrec[fld]
+                ):
                     match = False
                     fmatch = False
-                elif isinstance(rawrec[fld], list) and any([item.startswith("rec") for item in rawrec[fld]]):
+                elif isinstance(rawrec[fld], list) and any(
+                    [
+                        item.startswith("rec")
+                        for item in rawrec[fld]
+                        if isinstance(item, str)
+                    ]
+                ):
                     rawuids = {rid_uid_map_raw[ridx] for ridx in rawrec[fld]}
                     reluids = {rid_uid_map_rel[ridx] for ridx in relrec[fld]}
                     if not len(rawrec[fld]) == len(relrec[fld]):
@@ -238,18 +275,34 @@ def compare_dicts(raw, rel):
                             diff_rec_count[table_i][fld]["rawmore"] += 1
                         else:
                             diff_rec_count[table_i][fld]["relmore"] += 1
-                        if len([rid for rid in rawrec[fld] if rid not in ce.filtered_records]) < len(rawrec[fld]):
+                        if len(
+                            [
+                                rid
+                                for rid in rawrec[fld]
+                                if rid not in ce.filtered_records
+                            ]
+                        ) < len(rawrec[fld]):
                             diff_rec_count[table_i][fld]["unfiltered"] += 1
-                            diff_rec_count[table_i][fld][rawrec["UID"]] = len(rawrec[fld]) - len(
-                                [rid for rid in rawrec[fld] if rid not in ce.filtered_records]
+                            diff_rec_count[table_i][fld][rawrec["UID"]] = len(
+                                rawrec[fld]
+                            ) - len(
+                                [
+                                    rid
+                                    for rid in rawrec[fld]
+                                    if rid not in ce.filtered_records
+                                ]
                             )
                     if len(rawuids) == len(reluids):
                         diff_rec_count[table_i][fld]["samenruids"] += 1
                     if rawuids != reluids:
                         match = False
                         fmatch = False
-                        diff_rec[table_i][fld]["raw"][rawrec["UID"]] = [uid for uid in rawuids if uid not in reluids]
-                        diff_rec[table_i][fld]["rel"][relrec["UID"]] = [uid for uid in reluids if uid not in rawuids]
+                        diff_rec[table_i][fld]["raw"][rawrec["UID"]] = [
+                            uid for uid in rawuids if uid not in reluids
+                        ]
+                        diff_rec[table_i][fld]["rel"][relrec["UID"]] = [
+                            uid for uid in reluids if uid not in rawuids
+                        ]
                         if len(rawuids) > len(reluids):
                             diff_rec_count[table_i][fld]["rawmoreuids"] += 1
                         elif len(rawuids) < len(reluids):
@@ -264,11 +317,16 @@ def compare_dicts(raw, rel):
                     match = False
                     fmatch = False
                     if isinstance(rawrec[fld], str):
-                        if re.sub(r"\s+", "", rawrec[fld]) == re.sub(r"\s+", "", relrec[fld]):
+                        if re.sub(r"\s+", "", rawrec[fld]) == re.sub(
+                            r"\s+", "", relrec[fld]
+                        ):
                             diff_string_count[table_i][fld]["ws"] += 1
                         elif rawrec[fld].lower() == relrec[fld].lower():
                             diff_string_count[table_i][fld]["c"] += 1
-                        elif re.sub(r"\s+", "", rawrec[fld]).lower() == re.sub(r"\s+", "", relrec[fld]).lower():
+                        elif (
+                            re.sub(r"\s+", "", rawrec[fld]).lower()
+                            == re.sub(r"\s+", "", relrec[fld]).lower()
+                        ):
                             diff_string_count[table_i][fld]["wsc"] += 1
                 if not fmatch:
                     examples[table_i][fld] = [
@@ -281,8 +339,32 @@ def compare_dicts(raw, rel):
                 matches[table_i][rawid] = relid
 
         print(f"Perfect matches: {len(list(set(matches[table_i].keys())))}")
-        if len(list(set(matches[table_i].keys()))) != len(raw["Data Request"][table_i]["records"].keys()):
-            print(f"Matches by UID: {len(list(set(matches_uid[table_i].keys())))}")
+        if len(list(set(matches[table_i].keys()))) != len(
+            raw["Data Request"][table_i]["records"].keys()
+        ):
+            print(
+                f"Matches by UID: {len(list(set(matches_uid[table_i].keys())))}"
+            )
+        # release UIDs not in raw
+        rel_unique = [
+            rid_uid_map_rel[rel_recid]
+            for rel_recid in rel["Data Request"][table_i]["records"].keys()
+            if rid_uid_map_rel[rel_recid]
+            not in [
+                rid_uid_map_raw[raw_recid]
+                for raw_recid in raw["Data Request"][table_i]["records"].keys()
+            ]
+        ]
+        if rel_unique:
+            print(dets)
+            print(
+                f"{sums}Unique UIDs in release export: {len(rel_unique)}{sume}"
+            )
+            print()
+            for uid in sorted(rel_unique):
+                print(f"  - {uid}")
+            print(dete)
+        # raw UIDs not in release
         if nomatch[table_i]:
             if long_summary:
                 print(dets)
@@ -310,7 +392,9 @@ def compare_dicts(raw, rel):
             for fld in diff_fields_count[table_i]:
                 diffstr = ""
                 if diff_string_count[table_i][fld]["ws"]:
-                    diffstr += f"whitespace {diff_string_count[table_i][fld]['ws']}, "
+                    diffstr += (
+                        f"whitespace {diff_string_count[table_i][fld]['ws']}, "
+                    )
                 if diff_string_count[table_i][fld]["c"]:
                     diffstr += f"case {diff_string_count[table_i][fld]['c']}, "
                 if diff_string_count[table_i][fld]["wsc"]:
@@ -321,7 +405,8 @@ def compare_dicts(raw, rel):
                 if diff_rec_count[table_i][fld]["unfiltered"]:
                     diffrecs += f" (unfiltered records encountered {diff_rec_count[table_i][fld]['unfiltered']} times)"
                     if (
-                        diff_rec_count[table_i][fld]["rawmore"] + diff_rec_count[table_i][fld]["relmore"]
+                        diff_rec_count[table_i][fld]["rawmore"]
+                        + diff_rec_count[table_i][fld]["relmore"]
                         != diff_fields_count[table_i][fld]
                     ):
                         print(
@@ -345,14 +430,24 @@ def compare_dicts(raw, rel):
             if dets:
                 print()
             for fld in examples[table_i].keys():
-                print(f"{h4s}Field '{fld}' in table '{table_i}'       UID: '{examples[table_i][fld][2]}'{h4e}")
+                print(
+                    f"{h4s}Field '{fld}' in table '{table_i}'       UID: '{examples[table_i][fld][2]}'{h4e}"
+                )
                 if code:
                     print()
                 if isinstance(examples[table_i][fld][1], list) and any(
-                    [item.startswith("rec") for item in examples[table_i][fld][1] if isinstance(item, str)]
+                    [
+                        item.startswith("rec")
+                        for item in examples[table_i][fld][1]
+                        if isinstance(item, str)
+                    ]
                 ):
-                    print(f"- release: List of record ids with {len(examples[table_i][fld][1])} elements")
-                    print(f"  - unique UIDs in release {diff_rec[table_i][fld]['rel'][examples[table_i][fld][2]]}")
+                    print(
+                        f"- release: List of record ids with {len(examples[table_i][fld][1])} elements"
+                    )
+                    print(
+                        f"  - unique UIDs in release {diff_rec[table_i][fld]['rel'][examples[table_i][fld][2]]}"
+                    )
                 elif isinstance(examples[table_i][fld][1], str):
                     print("- release:")
                     if code:
@@ -363,12 +458,22 @@ def compare_dicts(raw, rel):
                     if code:
                         print()
                 else:
-                    print(f"- release: {code1}{examples[table_i][fld][1]}{code1}")
+                    print(
+                        f"- release: {code1}{examples[table_i][fld][1]}{code1}"
+                    )
                 if isinstance(examples[table_i][fld][0], list) and any(
-                    [item.startswith("rec") for item in examples[table_i][fld][0] if isinstance(item, str)]
+                    [
+                        item.startswith("rec")
+                        for item in examples[table_i][fld][0]
+                        if isinstance(item, str)
+                    ]
                 ):
-                    print(f"- raw: List of record ids with {len(examples[table_i][fld][0])} elements")
-                    print(f"  - unique UIDs in raw {diff_rec[table_i][fld]['raw'][examples[table_i][fld][2]]}")
+                    print(
+                        f"- raw: List of record ids with {len(examples[table_i][fld][0])} elements"
+                    )
+                    print(
+                        f"  - unique UIDs in raw {diff_rec[table_i][fld]['raw'][examples[table_i][fld][2]]}"
+                    )
                 elif isinstance(examples[table_i][fld][0], str):
                     print("- raw:")
                     if code:
@@ -390,24 +495,45 @@ def compare_dicts(raw, rel):
             for fld in examples[table_i].keys():
                 if (
                     isinstance(examples[table_i][fld][1], list)
-                    and any([item.startswith("rec") for item in examples[table_i][fld][1] if isinstance(item, str)])
+                    and any(
+                        [
+                            item.startswith("rec")
+                            for item in examples[table_i][fld][1]
+                            if isinstance(item, str)
+                        ]
+                    )
                 ) or (
                     isinstance(examples[table_i][fld][0], list)
-                    and any([item.startswith("rec") for item in examples[table_i][fld][0] if isinstance(item, str)])
+                    and any(
+                        [
+                            item.startswith("rec")
+                            for item in examples[table_i][fld][0]
+                            if isinstance(item, str)
+                        ]
+                    )
                 ):
                     printfld = False
                     uidlist = []
                     if diff_rec[table_i][fld]["raw"]:
-                        uidlist.extend(list(diff_rec[table_i][fld]["raw"].keys()))
+                        uidlist.extend(
+                            list(diff_rec[table_i][fld]["raw"].keys())
+                        )
                     if diff_rec[table_i][fld]["rel"]:
-                        uidlist.extend(list(diff_rec[table_i][fld]["rel"].keys()))
+                        uidlist.extend(
+                            list(diff_rec[table_i][fld]["rel"].keys())
+                        )
                     for uid in set(uidlist):
-                        if diff_rec[table_i][fld]["raw"][uid] or diff_rec[table_i][fld]["rel"][uid]:
+                        if (
+                            diff_rec[table_i][fld]["raw"][uid]
+                            or diff_rec[table_i][fld]["rel"][uid]
+                        ):
                             if not printsummary:
                                 if dets:
                                     print()
                                 print(dets)
-                                print(f"{sums}Full differences in record references (listed as UIDs):{sume}")
+                                print(
+                                    f"{sums}Full differences in record references (listed as UIDs):{sume}"
+                                )
                                 print()
                                 printsummary = True
                             if not printfld:

--- a/scripts/check_consolidation_and_transformation.py
+++ b/scripts/check_consolidation_and_transformation.py
@@ -1,0 +1,627 @@
+import copy
+import re
+import sys
+from collections import defaultdict
+
+import data_request_api.content.consolidate_export as ce
+import data_request_api.content.dreq_content as dc
+import data_request_api.content.dump_transformation as dtrans
+from data_request_api.utilities.logger import (
+    change_log_file,
+    change_log_level,
+    get_logger,
+)
+from data_request_api.utilities.tools import (
+    read_json_input_file_content,
+    write_json_output_file_content,
+)
+
+# Print consolidation log and full list of unmatched records
+long_summary = True
+
+change_log_file(default=True)
+if long_summary:
+    change_log_level("debug")
+else:
+    change_log_level("critical")
+logger = get_logger()
+
+if len(sys.argv) > 1:
+    version = sys.argv[1]
+else:
+    print(
+        "Please provide a version as first argument and optionally 'md' as second argument to generate markdown output:"
+    )
+    print("python", sys.argv[0], "<version> [md]")
+    sys.exit(1)
+
+# Whether to use Markdown/html formatting
+if len(sys.argv) > 2 and sys.argv[2] == "md":
+    h1s = "<h1>"
+    h1e = "</h1>"
+    h2s = "<h2>"
+    h2e = "</h2>"
+    h3s = "<h3>"
+    h3e = "</h3>"
+    h4s = "<h4>"
+    h4e = "</h4>"
+    dets = "<details>"
+    dete = "</details>"
+    sums = "<summary>"
+    sume = "</summary>"
+    code = "```"
+    code1 = "`"
+elif len(sys.argv) > 2 and sys.argv[2] != "md":
+    print("ERROR Unknown argument:", sys.argv[2])
+else:
+    h1s = ""
+    h1e = ""
+    h2s = ""
+    h2e = ""
+    h3s = ""
+    h3e = ""
+    h4s = ""
+    h4e = ""
+    dets = ""
+    dete = ""
+    sums = ""
+    sume = ""
+    code = ""
+    code1 = ""
+
+offlineRAW = version in dc.get_cached(export="raw")
+offlineREL = version in dc.get_cached(export="release")
+
+if not h1s:
+    print("#" * 50)
+print(f"{h1s}Checking consolidation of '{version}'{h1e}")
+if not h1s:
+    print("#" * 50)
+print(f"{dets}")
+
+
+# Load raw export with consolidation
+if long_summary:
+    if not h1s:
+        print("-" * 50)
+    print(f"{sums}{h2s}Consolidation log for raw export{h2e}{sume}")
+    if not h1s:
+        print("-" * 50)
+    if code:
+        print()
+    print(f"{code}")
+dreqraw = dc.load(
+    version,
+    export="raw",
+    consolidate=True,
+    offline=offlineRAW,
+    force_consolidate=True,
+)
+if long_summary:
+    print(f"{code}")
+    if code:
+        print()
+    print(f"{dete}")
+    if dete:
+        print()
+
+# Load release export with consolidation
+if long_summary:
+    print(f"{dets}")
+    if dets:
+        print()
+    if not h1s:
+        print("-" * 50)
+    print(f"{sums}{h2s}Consolidation log for release export{h2e}{sume}")
+    if not h1s:
+        print("-" * 50)
+    if code:
+        print()
+    print(f"{code}")
+dreqrel = dc.load(
+    version, export="release", consolidate=True, offline=offlineREL
+)
+if long_summary:
+    print(f"{code}")
+    if code:
+        print()
+    print(f"{dete}")
+    if dete:
+        print()
+
+# Transform raw export without consolidation
+if long_summary:
+    print(f"{dets}")
+    if dets:
+        print()
+    if not h1s:
+        print("-" * 50)
+    print(
+        f"{sums}{h2s}Transformation log for raw export without prior consolidation{h2e}{sume}"
+    )
+    if not h1s:
+        print("-" * 50)
+    if code:
+        print()
+    print(f"{code}")
+rawDR, rawVS = dtrans.transform_content(
+    dc.load(version, export="raw", consolidate=False, offline=True), version
+)
+if long_summary:
+    print(f"{code}")
+    if code:
+        print()
+    print(f"{dete}")
+    if dete:
+        print()
+
+# Transform raw export with consolidation
+if long_summary:
+    print(f"{dets}")
+    if dets:
+        print()
+    if not h1s:
+        print("-" * 50)
+    print(
+        f"{sums}{h2s}Transformation log for raw export with prior consolidation{h2e}{sume}"
+    )
+    if not h1s:
+        print("-" * 50)
+    if code:
+        print()
+    print(f"{code}")
+rawconsDR, rawconsVS = dtrans.transform_content(copy.deepcopy(dreqraw), version)
+if long_summary:
+    print(f"{code}")
+    if code:
+        print()
+    print(f"{dete}")
+    if dete:
+        print()
+
+# Transform release export
+if long_summary:
+    print(f"{dets}")
+    if dets:
+        print()
+    if not h1s:
+        print("-" * 50)
+    print(f"{sums}{h2s}Transformation log for release export{h2e}{sume}")
+    if not h1s:
+        print("-" * 50)
+    if code:
+        print()
+    print(f"{code}")
+relconsDR, relconsVS = dtrans.transform_content(copy.deepcopy(dreqrel), version)
+if long_summary:
+    print(f"{code}")
+    if code:
+        print()
+    print(f"{dete}")
+    if dete:
+        print()
+
+
+def compare_dicts(raw, rel):
+    print()
+
+    if len(raw.keys()) != len(rel.keys()):
+        print("ERROR: Different number of tables")
+        print("Unique in raw:", [i for i in raw.keys() if i not in rel.keys()])
+        print(
+            "Unique in release:", [i for i in rel.keys() if i not in raw.keys()]
+        )
+
+    # Clear version
+    raw.pop("version", None)
+    rel.pop("version", None)
+
+    # Collect differences in dictionaries
+    matches = defaultdict(lambda: defaultdict())
+    matches_uid = defaultdict(lambda: defaultdict())
+    examples = defaultdict(lambda: defaultdict())
+    diff_fields_count = defaultdict(lambda: defaultdict(int))
+    diff_string_count = defaultdict(
+        lambda: defaultdict(lambda: defaultdict(int))
+    )
+    diff_rec_count = defaultdict(lambda: defaultdict(lambda: defaultdict(int)))
+    diff_rec = defaultdict(
+        lambda: defaultdict(lambda: defaultdict(lambda: defaultdict(list)))
+    )
+
+    # Comparison for each table and field and record
+    for table_i in raw:
+        print()
+        print("-" * 50)
+        print(
+            f'{table_i}    (# records - raw: {len(raw[table_i].keys())} - release: {len(rel[table_i].keys()) if table_i in rel else "N/A"})'
+        )
+        print("-" * 50)
+        print()
+        if table_i not in rel:
+            print(
+                f"ERROR: '{table_i}' is missing or named differently in release export"
+            )
+            continue
+
+        # Compare records
+        nomatch = defaultdict(list)
+        for rawid, rawrec in raw[table_i].items():
+            # Match raw and release records via uid (not possible pre v1.2)
+            relid = rawid
+            if relid not in rel[table_i]:
+                nomatch[table_i].append(rawid)
+                continue
+            relrec = rel[table_i][relid]
+
+            # "Image" field in Opportunity table is a nested dictionary and not relevant - so skip this field
+            if table_i == "opportunities" and "image" in relrec:
+                relrec.pop("image")
+            if table_i == "opportunities" and "image" in rawrec:
+                rawrec.pop("image")
+
+            # Compare records to find fields that differ
+            # Distinguish
+            #  - match: all fields match
+            #  - fmatch: current field matches
+            # If fields reference other record(s), compare only referenced UIDs
+            match = True
+            for fld in set(rawrec.keys()) | set(relrec.keys()):
+                fmatch = True
+                if fld not in relrec.keys():
+                    if rawrec[fld]:
+                        match = False
+                        fmatch = False
+                        if isinstance(rawrec[fld], list) and any(
+                            [item.startswith("link") for item in rawrec[fld]]
+                        ):
+                            diff_rec_count[table_i][fld]["rawmore"] += 1
+                            diff_rec_count[table_i][fld]["rawmoreuids"] += 1
+                            rawuids = {
+                                ridx.removeprefix("link::")
+                                for ridx in rawrec[fld]
+                            }
+                            diff_rec[table_i][fld]["raw"][rawid] = list(rawuids)
+                    else:
+                        continue
+                elif fld not in rawrec.keys():
+                    if relrec[fld]:
+                        match = False
+                        fmatch = False
+                        if isinstance(relrec[fld], list) and any(
+                            [item.startswith("link") for item in relrec[fld]]
+                        ):
+                            diff_rec_count[table_i][fld]["relmore"] += 1
+                            diff_rec_count[table_i][fld]["relmoreuids"] += 1
+                            reluids = {
+                                ridx.removeprefix("link::")
+                                for ridx in relrec[fld]
+                            }
+                            diff_rec[table_i][fld]["rel"][relid] = list(reluids)
+                    else:
+                        continue
+                elif not rawrec[fld] and not relrec[fld]:
+                    continue
+                elif not isinstance(rawrec[fld], type(relrec[fld])) and (
+                    rawrec[fld] or relrec[fld]
+                ):
+                    match = False
+                    fmatch = False
+                elif isinstance(rawrec[fld], list) and any(
+                    [item.startswith("rec") for item in rawrec[fld]]
+                ):
+                    rawuids = {
+                        ridx.removeprefix("link::") for ridx in rawrec[fld]
+                    }
+                    reluids = {
+                        ridx.removeprefix("link::") for ridx in relrec[fld]
+                    }
+                    if not len(rawrec[fld]) == len(relrec[fld]):
+                        match = False
+                        fmatch = False
+                        if len(rawrec[fld]) > len(relrec[fld]):
+                            diff_rec_count[table_i][fld]["rawmore"] += 1
+                        else:
+                            diff_rec_count[table_i][fld]["relmore"] += 1
+                        if len(
+                            [
+                                rid
+                                for rid in rawrec[fld]
+                                if rid not in ce.filtered_records
+                            ]
+                        ) < len(rawrec[fld]):
+                            diff_rec_count[table_i][fld]["unfiltered"] += 1
+                            diff_rec_count[table_i][fld][rawrec["UID"]] = len(
+                                rawrec[fld]
+                            ) - len(
+                                [
+                                    rid
+                                    for rid in rawrec[fld]
+                                    if rid not in ce.filtered_records
+                                ]
+                            )
+                    if len(rawuids) == len(reluids):
+                        diff_rec_count[table_i][fld]["samenruids"] += 1
+                    if rawuids != reluids:
+                        match = False
+                        fmatch = False
+                        diff_rec[table_i][fld]["raw"][rawid] = [
+                            uid for uid in rawuids if uid not in reluids
+                        ]
+                        diff_rec[table_i][fld]["rel"][relid] = [
+                            uid for uid in reluids if uid not in rawuids
+                        ]
+                        if len(rawuids) > len(reluids):
+                            diff_rec_count[table_i][fld]["rawmoreuids"] += 1
+                        elif len(rawuids) < len(reluids):
+                            diff_rec_count[table_i][fld]["relmoreuids"] += 1
+                    else:
+                        diff_rec_count[table_i][fld]["sameuids"] += 1
+                elif isinstance(rawrec[fld], list):
+                    if not sorted(rawrec[fld]) == sorted(relrec[fld]):
+                        match = False
+                        fmatch = False
+                elif rawrec[fld] != relrec[fld]:
+                    match = False
+                    fmatch = False
+                    if isinstance(rawrec[fld], str):
+                        if re.sub(r"\s+", "", rawrec[fld]) == re.sub(
+                            r"\s+", "", relrec[fld]
+                        ):
+                            diff_string_count[table_i][fld]["ws"] += 1
+                        elif rawrec[fld].lower() == relrec[fld].lower():
+                            diff_string_count[table_i][fld]["c"] += 1
+                        elif (
+                            re.sub(r"\s+", "", rawrec[fld]).lower()
+                            == re.sub(r"\s+", "", relrec[fld]).lower()
+                        ):
+                            diff_string_count[table_i][fld]["wsc"] += 1
+                if not fmatch:
+                    examples[table_i][fld] = [
+                        rawrec[fld] if fld in rawrec else "UNDEFINED",
+                        relrec[fld] if fld in relrec else "UNDEFINED",
+                        rawid,
+                    ]
+                    diff_fields_count[table_i][fld] += 1
+            if match:
+                matches[table_i][rawid] = relid
+
+        print(f"Perfect matches: {len(list(set(matches[table_i].keys())))}")
+        if len(list(set(matches[table_i].keys()))) != len(raw[table_i].keys()):
+            print(
+                f"Matches by UID: {len(list(set(matches_uid[table_i].keys())))}"
+            )
+        # release UIDs not in raw
+        rel_unique = [
+            rel_recid
+            for rel_recid in rel[table_i].keys()
+            if rel_recid not in raw[table_i].keys()
+        ]
+        if rel_unique:
+            print(dets)
+            print(
+                f"{sums}Unique UIDs in release export: {len(rel_unique)}{sume}"
+            )
+            print()
+            for uid in sorted(rel_unique):
+                print(f"  - {uid}")
+            print(dete)
+        # raw UIDs not in release
+        if nomatch[table_i]:
+            if long_summary:
+                print(dets)
+                print(f"{sums}No matches: {len(nomatch[table_i])}{sume}")
+                print()
+                for uid in nomatch[table_i]:
+                    print(f"  - {uid}")
+                print(dete)
+            else:
+                print(f"No matches: {len(nomatch[table_i])}")
+        if len(examples[table_i].keys()) > 0:
+            print()
+            print(f"{h4s}Differences occurred for the following fields:{h4e}")
+            print()
+            for fld in diff_fields_count[table_i]:
+                diffstr = ""
+                if diff_string_count[table_i][fld]["ws"]:
+                    diffstr += (
+                        f"whitespace {diff_string_count[table_i][fld]['ws']}, "
+                    )
+                if diff_string_count[table_i][fld]["c"]:
+                    diffstr += f"case {diff_string_count[table_i][fld]['c']}, "
+                if diff_string_count[table_i][fld]["wsc"]:
+                    diffstr += f"whitespace&case {diff_string_count[table_i][fld]['wsc']}, "
+                diffrecs = ""
+                if diff_rec_count[table_i][fld]["rawmore"]:
+                    diffrecs += f" (more records in raw export in {diff_rec_count[table_i][fld]['rawmore']} cases)"
+                if diff_rec_count[table_i][fld]["unfiltered"]:
+                    diffrecs += f" (unfiltered records encountered {diff_rec_count[table_i][fld]['unfiltered']} times)"
+                    if (
+                        diff_rec_count[table_i][fld]["rawmore"]
+                        + diff_rec_count[table_i][fld]["relmore"]
+                        != diff_fields_count[table_i][fld]
+                    ):
+                        print(
+                            f"ERROR counting differences for '{table_i}'@'{fld}': {diff_rec_count[table_i][fld]['rawmore']} + {diff_rec_count[table_i][fld]['relmore']} != {diff_fields_count[table_i][fld]}"
+                        )
+                if diff_rec_count[table_i][fld]["rawmoreuids"]:
+                    diffrecs += f" (More UIDs raw: {diff_rec_count[table_i][fld]['rawmoreuids']} cases)"
+                if diff_rec_count[table_i][fld]["relmoreuids"]:
+                    diffrecs += f" (More UIDs release: {diff_rec_count[table_i][fld]['relmoreuids']} cases)"
+                if diff_rec_count[table_i][fld]["samenruids"]:
+                    diffrecs += f" (Same number of UIDs: {diff_rec_count[table_i][fld]['samenruids']} cases)"
+                if diff_rec_count[table_i][fld]["sameuids"]:
+                    diffrecs += f" (Exact same UIDs: {diff_rec_count[table_i][fld]['sameuids']} cases)"
+                print(
+                    f"- {diff_fields_count[table_i][fld]} for field '{fld}' {'(Differences only in: ' + diffstr.strip(', ') + ')' if diffstr else ''}{diffrecs if diffrecs else ''}"
+                )
+            if dets:
+                print()
+            print(dets)
+            print(f"{sums}Examples:{sume}")
+            if dets:
+                print()
+            for fld in examples[table_i].keys():
+                print(
+                    f"{h4s}Field '{fld}' in table '{table_i}'       UID: '{examples[table_i][fld][2]}'{h4e}"
+                )
+                if code:
+                    print()
+                if isinstance(examples[table_i][fld][1], list) and any(
+                    [
+                        item.startswith("rec")
+                        for item in examples[table_i][fld][1]
+                        if isinstance(item, str)
+                    ]
+                ):
+                    print(
+                        f"- release: List of record ids with {len(examples[table_i][fld][1])} elements"
+                    )
+                    print(
+                        f"  - unique UIDs in release {diff_rec[table_i][fld]['rel'][examples[table_i][fld][2]]}"
+                    )
+                elif isinstance(examples[table_i][fld][1], str):
+                    print("- release:")
+                    if code:
+                        print()
+                    print(code)
+                    print(f"'{examples[table_i][fld][1]}'")
+                    print(code)
+                    if code:
+                        print()
+                else:
+                    print(
+                        f"- release: {code1}{examples[table_i][fld][1]}{code1}"
+                    )
+                if isinstance(examples[table_i][fld][0], list) and any(
+                    [
+                        item.startswith("rec")
+                        for item in examples[table_i][fld][0]
+                        if isinstance(item, str)
+                    ]
+                ):
+                    print(
+                        f"- raw: List of record ids with {len(examples[table_i][fld][0])} elements"
+                    )
+                    print(
+                        f"  - unique UIDs in raw {diff_rec[table_i][fld]['raw'][examples[table_i][fld][2]]}"
+                    )
+                elif isinstance(examples[table_i][fld][0], str):
+                    print("- raw:")
+                    if code:
+                        print()
+                    print(code)
+                    print(f"'{examples[table_i][fld][0]}'")
+                    print(code)
+                    if code:
+                        print()
+                else:
+                    print(f"- raw: {code1}{examples[table_i][fld][0]}{code1}")
+            if dete:
+                print()
+            if dete:
+                print(dete)
+            if dete:
+                print()
+            printsummary = False
+            for fld in examples[table_i].keys():
+                if (
+                    isinstance(examples[table_i][fld][1], list)
+                    and any(
+                        [
+                            item.startswith("rec")
+                            for item in examples[table_i][fld][1]
+                            if isinstance(item, str)
+                        ]
+                    )
+                ) or (
+                    isinstance(examples[table_i][fld][0], list)
+                    and any(
+                        [
+                            item.startswith("rec")
+                            for item in examples[table_i][fld][0]
+                            if isinstance(item, str)
+                        ]
+                    )
+                ):
+                    printfld = False
+                    uidlist = []
+                    if diff_rec[table_i][fld]["raw"]:
+                        uidlist.extend(
+                            list(diff_rec[table_i][fld]["raw"].keys())
+                        )
+                    if diff_rec[table_i][fld]["rel"]:
+                        uidlist.extend(
+                            list(diff_rec[table_i][fld]["rel"].keys())
+                        )
+                    for uid in set(uidlist):
+                        if (
+                            diff_rec[table_i][fld]["raw"][uid]
+                            or diff_rec[table_i][fld]["rel"][uid]
+                        ):
+                            if not printsummary:
+                                if dets:
+                                    print()
+                                print(dets)
+                                print(
+                                    f"{sums}Full differences in record references (listed as UIDs):{sume}"
+                                )
+                                print()
+                                printsummary = True
+                            if not printfld:
+                                print(f"- '{fld}' ({table_i})")
+                                printfld = True
+                            print(f"  - {uid}")
+                            if diff_rec[table_i][fld]["raw"][uid]:
+                                print(
+                                    f"    - unique in raw ({len(diff_rec[table_i][fld]['raw'][uid])}):",
+                                    diff_rec[table_i][fld]["raw"][uid],
+                                )
+                            if diff_rec[table_i][fld]["rel"][uid]:
+                                print(
+                                    f"    - unique in release ({len(diff_rec[table_i][fld]['rel'][uid])}):",
+                                    diff_rec[table_i][fld]["rel"][uid],
+                                )
+            if printsummary:
+                print(dete)
+                if dete:
+                    print()
+
+
+# Compare consolidated raw vs raw
+print()
+if not h1s:
+    print("#" * 50)
+print(f"{h1s}DR content: consolidated raw vs raw{h1e}")
+if not h1s:
+    print("#" * 50)
+print(f"{dets}")
+compare_dicts(rawconsDR, rawDR)
+print()
+if not h1s:
+    print("#" * 50)
+print(f"{h1s}VS content: consolidated raw vs raw{h1e}")
+if not h1s:
+    print("#" * 50)
+print(f"{dets}")
+compare_dicts(rawconsVS, rawVS)
+print()
+
+# Compare raw vs release
+print()
+if not h1s:
+    print("#" * 50)
+print(f"{h1s}DR content: consolidated raw vs release{h1e}")
+if not h1s:
+    print("#" * 50)
+print(f"{dets}")
+compare_dicts(rawDR, relconsDR)
+print()
+if not h1s:
+    print("#" * 50)
+print(f"{h1s}VS content: consolidated raw vs release{h1e}")
+if not h1s:
+    print("#" * 50)
+print(f"{dets}")
+compare_dicts(rawVS, relconsVS)
+print()


### PR DESCRIPTION
- Added binder configuration
- Updated check_consolidation scripts
- Added check script for consolidation plus transformation
- Consolidation updates for v1.2.1
  - added new filters for CF standard names and Physical parameters
  - now stripping whitespace from strings in both export types
  - now adding missing spaces after commas in both export types
  - update data type of table fields
- Small fix for CLI function `estimate_dreq_volume`: Ignore folders / Consider only files when looking for input file
- Added tests for CLI functions esimate_dreq_volume and compare_variables
- Now printing config file location when initializing via CLI (closes issue #102)
- Removed duplicate `pyyaml` entry in `requirements.txt`