### PR TITLE
Bugfix now that some variables have branded variable names of the for…

### DIFF
--- a/data_request_api/data_request_api/query/dreq_query.py
+++ b/data_request_api/data_request_api/query/dreq_query.py
@@ -14,6 +14,7 @@ import hashlib
 import json
 import os
 import re
+import warnings
 from collections import OrderedDict
 
 from data_request_api.query.dreq_classes import (
@@ -951,8 +952,9 @@ def get_variables_metadata(content, dreq_version,
         # Get info on branded variable name, if available
         if hasattr(var, 'branded_variable_name'):
             branded_variable_name = var.branded_variable_name
-            assert branded_variable_name.count('_') == 1, \
-                'Expected one (and only one) underscore in branded variable name: ' + branded_variable_name
+            if branded_variable_name.count('_') != 1:
+                warnings.warn('Expected one (and only one) underscore in branded variable name: ' + branded_variable_name)
+            
             variableRootDD = branded_variable_name.split('_')[0]
             var_info.update({
                 'variableRootDD': variableRootDD,


### PR DESCRIPTION
…m 'unknownNN' (NN=01..05)

Found this when I was running `get_variables_metadata` -- there are some variables with branded variable name set to `unknownNN` (NN = 01..05) and the assert statement causes script failure.

I've downgraded this to a warning to allow the script to run (we don't have logging set up in this module)

Tests pass.