### PR TITLE
api warning bugfix

### DIFF
--- a/data_request_api/data_request_api/utilities/config.py
+++ b/data_request_api/data_request_api/utilities/config.py
@@ -160,8 +160,12 @@ def update_config(key, value):
 
 def check_api_version():
     """
-    Check pypi for latest release of the software.
-    Warn user if the installed version is not the latest release.
+    Check pypi for latest release of the software and warn user if the installed version is not the latest release.
+    Intended behaviour, assuming that latest version is '1.2.2':
+        installed_version = '1.2.1' ==> warn user
+        installed_version = '1.2.2' ==> don't warn user
+        installed_version = '1.2.1.dev8+g6aa6222.d20250515' ==> warn user
+        installed_version = '1.2.2.dev8+g6aa6222.d20250515' ==> don't warn user
     """
     try:
         installed_version = version(PACKAGE_NAME)
@@ -177,20 +181,7 @@ def check_api_version():
         print(f"Error checking PyPI: {e}")
         return
 
-    if '.dev' in installed_version:
-        # Development versions are indicated by the latest version number followed by 'dev' + stuff.
-        # Example: '1.2.1.dev8+g6aa6222.d20250515'
-        # For development versions, only issue the warning if the version number preceding 'dev' is before
-        # the latest version.
-        # For example, if latest_version is '1.2.2':
-        #   installed_version = '1.2.1.dev8+g6aa6222.d20250515' ==> issue the warning
-
-        #   installed_version = '1.2.2.dev8+g6aa6222.d20250515' ==> don't issue the warning
-        check_version = installed_version.split('.dev')[0]
-    else:
-        check_version = installed_version
-
-    if check_version < latest_version:
+    if installed_version < latest_version:
         # Warn user that installed version is earlier than the latest version on pypi
         msg = f"Warning: the installed version of {PACKAGE_NAME} is not the latest version available from PyPI!\n"
         msg += f"Latest version on PyPI:  {latest_version}\n"

--- a/data_request_api/data_request_api/utilities/config.py
+++ b/data_request_api/data_request_api/utilities/config.py
@@ -177,8 +177,21 @@ def check_api_version():
         print(f"Error checking PyPI: {e}")
         return
 
-    if not installed_version > latest_version:
-        # Warn user that installed version isn't the same as the latest pypi version
+    if '.dev' in installed_version:
+        # Development versions are indicated by the latest version number followed by 'dev' + stuff.
+        # Example: '1.2.1.dev8+g6aa6222.d20250515'
+        # For development versions, only issue the warning if the version number preceding 'dev' is before
+        # the latest version.
+        # For example, if latest_version is '1.2.2':
+        #   installed_version = '1.2.1.dev8+g6aa6222.d20250515' ==> issue the warning
+
+        #   installed_version = '1.2.2.dev8+g6aa6222.d20250515' ==> don't issue the warning
+        check_version = installed_version.split('.dev')[0]
+    else:
+        check_version = installed_version
+
+    if check_version < latest_version:
+        # Warn user that installed version is earlier than the latest version on pypi
         msg = f"Warning: the installed version of {PACKAGE_NAME} is not the latest version available from PyPI!\n"
         msg += f"Latest version on PyPI:  {latest_version}\n"
         msg += f"Installed version:       {installed_version}\n"


### PR DESCRIPTION
Minor additional thing for https://github.com/CMIP-Data-Request/CMIP7_DReq_Software/issues/159.

API warning was wrongly triggered for this case:
```
Warning: the installed version of CMIP7_data_request_api is not the latest version available from PyPI!
Latest version on PyPI:  1.2.2
Installed version:       1.2.2
```
Adjusted the condition to fix this.

Intended behaviour: assuming latest version on pypi is 1.2.2, then for installed version of...
v1.2.1 ==> show warning
v1.2.1.dev8+g6aa6222.d20250515 ==> show warning
v.1.2.2 ==> don't show warning
v.1.2.2..dev8+g6aa6222.d20250515 ==> don't show warning
