### PR TITLE
restore cli test for compare_variables

### DIFF
--- a/data_request_api/data_request_api/tests/test_cli.py
+++ b/data_request_api/data_request_api/tests/test_cli.py
@@ -278,11 +278,11 @@ class TestCompareVariables:
         with open(self.temp_config_file, "w") as fh:
             config = {
                 "consolidate": self.consolidate == "consolidate",
+                "variable_name": "CMIP6 Compound Name",
                 "cache_dir": str(self.temp_config_file.parent),
             }
             yaml.dump(config, fh)
-        # dc.load("v1.2")
-        # dc.load("v1.2.1")
+        dc.load("v1.2.1")
         dc.load("v1.2.2")
 
     def test_compare_variables(self, temp_config_file, consolidate):
@@ -307,8 +307,7 @@ class TestCompareVariables:
                 sys.executable,
                 "-m",
                 "data_request_api.command_line.get_variables_metadata",
-                # "v1.2",
-                "v1.2.2",
+                "v1.2.1",
                 ofileA,
             ],
             capture_output=True,
@@ -322,7 +321,6 @@ class TestCompareVariables:
                 sys.executable,
                 "-m",
                 "data_request_api.command_line.get_variables_metadata",
-                # "v1.2.1",
                 "v1.2.2",
                 ofileB,
             ],


### PR DESCRIPTION
For the v1.2.2 software release I modified `test_compare_variables` to compare v1.2.2 to v1.2.2, since this would work using the CMIP7 Compound Name, which is now the default config file setting of `variable_name`. This checks the script runs, but of course the intention is to compare different DR content versions, as was done before! To do that, the CMIP6 Compound Name needs to be used, which required the tests to use their own config file, as discussed in https://github.com/CMIP-Data-Request/CMIP7_DReq_Software/issues/119. Now that I see how to do that - thanks @sol1105! - comparison of two versions (I used v1.2.1 vs v1.2.2) is restored in the test.

I've labelled this PR as work-in-progress because maybe we want to consider making other tests use both types of compound name (CMIP6 & CMIP7), to ensure the tests cover support for that. 