### PR TITLE
Consolidation update

### DIFF
--- a/data_request_api/data_request_api/content/consolidate_export.py
+++ b/data_request_api/data_request_api/content/consolidate_export.py
@@ -3,12 +3,10 @@ from collections import defaultdict
 
 from data_request_api.utilities.logger import get_logger  # noqa
 
-from .mapping_table import (
-    version_consistency,
-    version_consistency_drop_fields,
-    version_consistency_drop_tables,
-    version_consistency_fields,
-)
+from .mapping_table import (version_consistency,
+                            version_consistency_drop_fields,
+                            version_consistency_drop_tables,
+                            version_consistency_fields)
 
 # Filtered records
 filtered_records = []
@@ -53,11 +51,15 @@ def _apply_consistency_fixes(data):
     # Table names
     for tfrom, tto in version_consistency.items():
         if tfrom in data:
-            logger.debug(f"Consistency across versions / releases - renaming table: {tfrom} -> {tto}")
+            logger.debug(
+                f"Consistency across versions / releases - renaming table: {tfrom} -> {tto}"
+            )
             data[tto] = data.pop(tfrom)
     for tfrom in version_consistency_drop_tables:
         if tfrom in data:
-            logger.debug(f"Consistency across versions / releases - dropping table: {tfrom}")
+            logger.debug(
+                f"Consistency across versions / releases - dropping table: {tfrom}"
+            )
             data.pop(tfrom)
     # Field names
     for tfrom, fnm in version_consistency_fields.items():
@@ -71,13 +73,17 @@ def _apply_consistency_fixes(data):
                     data[tfrom]["fields"][field_names[keyold]]["name"] = keynew
                     for r, v in data[tfrom]["records"].items():
                         if keyold in v:
-                            data[tfrom]["records"][r][keynew] = data[tfrom]["records"][r].pop(keyold)
+                            data[tfrom]["records"][r][keynew] = data[tfrom]["records"][
+                                r
+                            ].pop(keyold)
     for tfrom in version_consistency_drop_fields:
         if tfrom in data:
             field_names = {j["name"]: i for i, j in data[tfrom]["fields"].items()}
             for key in version_consistency_drop_fields[tfrom]:
                 if key in field_names:
-                    logger.debug(f"Consistency across versions / releases - dropping field in table '{tfrom}': '{key}'")
+                    logger.debug(
+                        f"Consistency across versions / releases - dropping field in table '{tfrom}': '{key}'"
+                    )
                     data[tfrom]["fields"].pop(field_names[key])
                     for r, v in data[tfrom]["records"].items():
                         if key in v:
@@ -95,12 +101,16 @@ def _apply_hard_fixes(data):
             f"Consistency across versions / releases - applying hard fixes for version '{data['Data Request']['version']}'"
         )
         # v1.2 raw: MIPs - merge recC5TLtnrU7SVcas into recdHS1Xys1I97ju4
-        for k, v in data["Data Request"]["MIPs"]["records"]["recC5TLtnrU7SVcas"].items():
+        for k, v in data["Data Request"]["MIPs"]["records"][
+            "recC5TLtnrU7SVcas"
+        ].items():
             if k != "MIP Short Name":
                 data["Data Request"]["MIPs"]["records"]["recdHS1Xys1I97ju4"][k] = v
         data["Data Request"]["MIPs"]["records"].pop("recC5TLtnrU7SVcas")
         # v1.2 raw: Table Identifiers - delete recWXLdtRuQkdcTqC
-        data["Data Request"]["CMIP6 Table Identifiers (legacy)"]["records"].pop("recWXLdtRuQkdcTqC")
+        data["Data Request"]["CMIP6 Table Identifiers (legacy)"]["records"].pop(
+            "recWXLdtRuQkdcTqC"
+        )
         # v1.2 raw: Table Identifiers - alter recWX81OMKJSjRjS7 (80ac3145-a698-11ef-914a-613c0433d878)
         chdict = {
             "UID": "80ab73f5-a698-11ef-914a-613c0433d878",
@@ -114,11 +124,13 @@ def _apply_hard_fixes(data):
             "Alternative Label": "6hrOcean",
         }
         for k, v in chdict.items():
-            data["Data Request"]["CMIP6 Table Identifiers (legacy)"]["records"]["recWX81OMKJSjRjS7"][k] = v
+            data["Data Request"]["CMIP6 Table Identifiers (legacy)"]["records"][
+                "recWX81OMKJSjRjS7"
+            ][k] = v
         # v1.2 raw: This Table Identifier is also missing from the CMIP6 Frequency (legacy) rectxxiQQwBXUszgx
-        data["Data Request"]["CMIP6 Frequency (legacy)"]["records"]["rectxxiQQwBXUszgx"]["Table Identifiers"].append(
-            "recWX81OMKJSjRjS7"
-        )
+        data["Data Request"]["CMIP6 Frequency (legacy)"]["records"][
+            "rectxxiQQwBXUszgx"
+        ]["Table Identifiers"].append("recWX81OMKJSjRjS7")
     return data
 
 
@@ -134,9 +146,13 @@ def _filter_references(val, key, table, rid, dtype=None):
         if len(filtered) != len(val):
             if filtered == []:
                 if len(val) == 1:
-                    logger.warning(f"'{table}': Filtered the only reference for '{key}' of record '{rid}'.")
+                    logger.warning(
+                        f"'{table}': Filtered the only reference for '{key}' of record '{rid}'."
+                    )
                 else:
-                    logger.warning(f"'{table}': Filtered all {len(val)} references for '{key}' of record '{rid}'.")
+                    logger.warning(
+                        f"'{table}': Filtered all {len(val)} references for '{key}' of record '{rid}'."
+                    )
             else:
                 logger.debug(
                     f"'{table}': Filtered {len(val) - len(filtered)} of {len(val)}"
@@ -150,7 +166,8 @@ def _filter_references(val, key, table, rid, dtype=None):
             if len(filtered) != len(vallist):
                 if filtered == []:
                     logger.warning(
-                        f"'{table}': Filtered all {len(vallist)} references for" f" '{key}' of record '{rid}'."
+                        f"'{table}': Filtered all {len(vallist)} references for"
+                        f" '{key}' of record '{rid}'."
                     )
                 else:
                     logger.debug(
@@ -159,7 +176,9 @@ def _filter_references(val, key, table, rid, dtype=None):
                     )
             return _fix_dtype(key, ",".join(filtered), dtype)
         elif val.strip() in filtered_records:
-            logger.warning(f"'{table}': Filtered the only reference for '{key}' of record '{rid}'.")
+            logger.warning(
+                f"'{table}': Filtered the only reference for '{key}' of record '{rid}'."
+            )
             return _fix_dtype(key, "", dtype)
         else:
             return _fix_dtype(key, _fix_str(val), dtype)
@@ -202,13 +221,26 @@ def _fix_str(var):
         return var
 
 
+def _fix_numeric_str(var):
+    """Removes invalid characters from strings that represent numeric values."""
+    if isinstance(var, str):
+        return re.sub(r"[^0-9eE\+\-\.]", "", var)
+    else:
+        return var
+
+
 def _fix_str_nested(data):
     """Adds missing space after commas and strips whitespace from strings in nested dictionary."""
     sub = re.sub
     pattern = r",(?=\S)"
     for table in data.values():
         for record in table["records"].values():
-            record.update({k: sub(pattern, ", ", v).strip() if isinstance(v, str) else v for k, v in record.items()})
+            record.update(
+                {
+                    k: sub(pattern, ", ", v).strip() if isinstance(v, str) else v
+                    for k, v in record.items()
+                }
+            )
 
 
 def _fix_dtype(fkey, fval, dtype=None):
@@ -218,34 +250,62 @@ def _fix_dtype(fkey, fval, dtype=None):
     if dtype is None:
         return fval
     elif dtype == "str":
-        logger.debug(f"Consolidate export: Converting field '{fkey}' ('{fval}') to string.")
+        logger.debug(
+            f"Consolidate export: Converting field '{fkey}' ('{fval}') to string."
+        )
         return str(fval)
     elif dtype == "int":
-        logger.debug(f"Consolidate export: Converting field '{fkey}' ('{fval}') to int.")
-        return int(fval)
+        logger.debug(
+            f"Consolidate export: Converting field '{fkey}' ('{fval}') to int."
+        )
+        return int(_fix_numeric_str(fval))
     elif dtype == "float":
-        logger.debug(f"Consolidate export: Converting field '{fkey}' ('{fval}') to float.")
-        return float(fval)
+        logger.debug(
+            f"Consolidate export: Converting field '{fkey}' ('{fval}') to float."
+        )
+        return float(_fix_numeric_str(fval))
     elif dtype == "listofstr":
-        logger.debug(f"Consolidate export: Converting field '{fkey}' to a list of strings.")
+        logger.debug(
+            f"Consolidate export: Converting field '{fkey}' to a list of strings."
+        )
         if isinstance(fval, list):
             return [str(v) for v in fval]
         else:
             return [str(fval)]
     elif dtype == "listofint":
-        logger.debug(f"Consolidate export: Converting field '{fkey}' to a list of ints.")
+        logger.debug(
+            f"Consolidate export: Converting field '{fkey}' to a list of ints."
+        )
         if isinstance(fval, list):
             return [int(v) for v in fval]
+        elif isinstance(fval, str):
+            if "," in fval:
+                return [int(ifval) for ifval in fval.replace(" ", "").split(",")]
+            elif " " in fval:
+                return [int(ifval) for ifval in fval.split() if ifval.strip() != ""]
+            else:
+                return [int(fval)]
         else:
             return [int(fval)]
     elif dtype == "listoffloat":
-        logger.debug(f"Consolidate export: Converting field '{fkey}' to a list of floats.")
+        logger.debug(
+            f"Consolidate export: Converting field '{fkey}' to a list of floats."
+        )
         if isinstance(fval, list):
             return [float(v) for v in fval]
+        elif isinstance(fval, str):
+            if "," in fval:
+                return [float(ifval) for ifval in fval.replace(" ", "").split(",")]
+            elif " " in fval:
+                return [float(ifval) for ifval in fval.split() if ifval.strip() != ""]
+            else:
+                return [float(fval)]
         else:
             return [float(fval)]
     else:
-        logger.warning(f"Consolidate export: Unsupported data type '{dtype}' for field '{fkey}'.")
+        logger.warning(
+            f"Consolidate export: Unsupported data type '{dtype}' for field '{fkey}'."
+        )
         return fval
 
 
@@ -292,13 +352,25 @@ def map_data(data, mapping_table, version, **kwargs):
             if mapinfo["source_base"] in data and any(
                 [st in data[mapinfo["source_base"]] for st in mapinfo["source_table"]]
             ):
-                source_table = [st for st in mapinfo["source_table"] if st in data[mapinfo["source_base"]]][0]
+                source_table = [
+                    st
+                    for st in mapinfo["source_table"]
+                    if st in data[mapinfo["source_base"]]
+                ][0]
                 if "internal_filters" in mapinfo:
-                    for record_id, record in data[mapinfo["source_base"]][source_table]["records"].items():
+                    for record_id, record in data[mapinfo["source_base"]][source_table][
+                        "records"
+                    ].items():
                         filter_results = []
-                        for filter_key, filter_val in mapinfo["internal_filters"].items():
+                        for filter_key, filter_val in mapinfo[
+                            "internal_filters"
+                        ].items():
                             if all(
-                                [filter_alias not in record for filter_alias in [filter_key] + filter_val["aliases"]]
+                                [
+                                    filter_alias not in record
+                                    for filter_alias in [filter_key]
+                                    + filter_val["aliases"]
+                                ]
                             ):
                                 filter_results.append(False)
                             elif filter_val["operator"] == "nonempty":
@@ -306,7 +378,8 @@ def map_data(data, mapping_table, version, **kwargs):
                                     any(
                                         [
                                             bool(record[fk])
-                                            for fk in [filter_key] + filter_val["aliases"]
+                                            for fk in [filter_key]
+                                            + filter_val["aliases"]
                                             if fk in record
                                         ]
                                     )
@@ -316,21 +389,32 @@ def map_data(data, mapping_table, version, **kwargs):
                                     if fk in record:
                                         if isinstance(record[filter_key], list):
                                             filter_results.append(
-                                                any(fj in filter_val["values"] for fj in record[filter_key])
+                                                any(
+                                                    fj in filter_val["values"]
+                                                    for fj in record[filter_key]
+                                                )
                                             )
                                             break
                                         else:
-                                            filter_results.append(record[filter_key] in filter_val["values"])
+                                            filter_results.append(
+                                                record[filter_key]
+                                                in filter_val["values"]
+                                            )
                             elif filter_val["operator"] == "not in":
                                 for fk in [filter_key] + filter_val["aliases"]:
                                     if fk in record:
                                         if isinstance(record[filter_key], list):
                                             filter_results.append(
-                                                any(fj not in filter_val["values"] for fj in record[filter_key])
+                                                any(
+                                                    fj not in filter_val["values"]
+                                                    for fj in record[filter_key]
+                                                )
                                             )
                                         break
                                 else:
-                                    filter_results.append(record[filter_key] not in filter_val["values"])
+                                    filter_results.append(
+                                        record[filter_key] not in filter_val["values"]
+                                    )
                         if not all(filter_results):
                             logger.debug(
                                 f"Filtered record '{record_id}'"
@@ -343,7 +427,9 @@ def map_data(data, mapping_table, version, **kwargs):
                             else:
                                 filtered_records_dict[table] = [record_id]
         for key in filtered_records_dict:
-            logger.debug(f"Filtered {len(filtered_records_dict[key])} records for '{key}'.")
+            logger.debug(
+                f"Filtered {len(filtered_records_dict[key])} records for '{key}'."
+            )
         logger.debug(f"Filtered {len(filtered_records)} records in total.")
 
         # Perform mapping in case of three-base structure
@@ -358,23 +444,36 @@ def map_data(data, mapping_table, version, **kwargs):
                 #   "internal_consistency" settings
                 # - filter references to records for fields that are not
                 #   internally mapped below
-                source_table = [st for st in mapinfo["source_table"] if st in data[mapinfo["source_base"]]][0]
-                logger.debug(f"Mapping '{mapinfo['source_base']}' : '{source_table}' -> '{table}'")
+                source_table = [
+                    st
+                    for st in mapinfo["source_table"]
+                    if st in data[mapinfo["source_base"]]
+                ][0]
+                logger.debug(
+                    f"Mapping '{mapinfo['source_base']}' : '{source_table}' -> '{table}'"
+                )
                 mapped_data["Data Request"][table] = {
                     **data[mapinfo["source_base"]][source_table],
                     "records": {
                         record_id: {
-                            mapinfo["internal_consistency"].get(reckey, reckey): _filter_references(
+                            mapinfo["internal_consistency"].get(
+                                reckey, reckey
+                            ): _filter_references(
                                 recvalue,
                                 reckey,
                                 table,
                                 record_id,
-                                mapinfo["field_dtypes"].get(mapinfo["internal_consistency"].get(reckey, reckey), None),
+                                mapinfo["field_dtypes"].get(
+                                    mapinfo["internal_consistency"].get(reckey, reckey),
+                                    None,
+                                ),
                             )
                             for reckey, recvalue in record.items()
                             if reckey not in mapinfo["drop_keys"]
                         }
-                        for record_id, record in data[mapinfo["source_base"]][source_table]["records"].items()
+                        for record_id, record in data[mapinfo["source_base"]][
+                            source_table
+                        ]["records"].items()
                         if record_id not in filtered_records
                     },
                 }
@@ -386,10 +485,13 @@ def map_data(data, mapping_table, version, **kwargs):
                         intm_table = [
                             tn
                             for tn in mapping_table.keys()
-                            if tn in mapping_table[tn]["source_table"] and tn == intm[attr]["table"]
+                            if tn in mapping_table[tn]["source_table"]
+                            and tn == intm[attr]["table"]
                         ][0]
                         intm_table_alias = [
-                            tn for tn in mapping_table[intm_table]["source_table"] if tn in data[intm[attr]["base"]]
+                            tn
+                            for tn in mapping_table[intm_table]["source_table"]
+                            if tn in data[intm[attr]["base"]]
                         ]
                         try:
                             intm_table_alias = intm_table_alias[0]
@@ -398,13 +500,22 @@ def map_data(data, mapping_table, version, **kwargs):
                             logger.error(errmsg)
                             raise ValueError(errmsg)
 
-                        for record_id, record in data[mapinfo["source_base"]][source_table]["records"].items():
+                        for record_id, record in data[mapinfo["source_base"]][
+                            source_table
+                        ]["records"].items():
                             if record_id in filtered_records:
                                 continue
-                            elif attr not in record or record[attr] is None or record[attr] == "" or record[attr] == []:
+                            elif (
+                                attr not in record
+                                or record[attr] is None
+                                or record[attr] == ""
+                                or record[attr] == []
+                            ):
                                 # Attribute name not found for record, but might have a different name
                                 #  in another export type or release version
-                                logger.debug(f"{table}: Attribute '{attr}' not found for record '{record_id}'.")
+                                logger.debug(
+                                    f"{table}: Attribute '{attr}' not found for record '{record_id}'."
+                                )
                                 attr_aliases = [
                                     a
                                     for a in mapinfo["internal_consistency"].keys()
@@ -439,7 +550,12 @@ def map_data(data, mapping_table, version, **kwargs):
                                     # raise TypeError({errmsg})
                                 else:
                                     attr_vals = list(
-                                        map(lambda x: x.strip('"'), re.split(r',\s*(?=(?:[^"]|"[^"]*")*$)', attr_vals))
+                                        map(
+                                            lambda x: x.strip('"'),
+                                            re.split(
+                                                r',\s*(?=(?:[^"]|"[^"]*")*$)', attr_vals
+                                            ),
+                                        )
                                     )
                             elif intm[attr]["operation"] == "":
                                 if isinstance(attr_vals, str):
@@ -468,7 +584,10 @@ def map_data(data, mapping_table, version, **kwargs):
                                     errmsg = f"Base '{intm[attr]['base']}' not found in data."
                                     logger.error(f"KeyError: {errmsg}")
                                     raise KeyError(errmsg)
-                                elif intm[attr]["base_copy_of_table"] not in data[mapinfo["source_base"]]:
+                                elif (
+                                    intm[attr]["base_copy_of_table"]
+                                    not in data[mapinfo["source_base"]]
+                                ):
                                     errmsg = f"Table '{intm[attr]['base_copy_of_table']}' not found in base '{mapinfo['source_base']}'."
                                     logger.error(f"KeyError: {errmsg}")
                                     raise KeyError(errmsg)
@@ -476,17 +595,23 @@ def map_data(data, mapping_table, version, **kwargs):
                                 recordIDs_new = []
                                 for attr_val in attr_vals:
                                     # The record copy in the current base
-                                    record_copy = data[mapinfo["source_base"]][intm[attr]["base_copy_of_table"]][
-                                        "records"
-                                    ][attr_val]
+                                    record_copy = data[mapinfo["source_base"]][
+                                        intm[attr]["base_copy_of_table"]
+                                    ]["records"][attr_val]
                                     # The entire list of records in the base of origin
-                                    recordlist = data[intm[attr]["base"]][intm_table_alias]["records"]
+                                    recordlist = data[intm[attr]["base"]][
+                                        intm_table_alias
+                                    ]["records"]
                                     recordID_new = _map_record_id(
                                         record_copy,
                                         recordlist,
                                         intm[attr]["map_by_key"],
                                     )
-                                    recordID_filtered = [r for r in recordID_new if r not in filtered_records]
+                                    recordID_filtered = [
+                                        r
+                                        for r in recordID_new
+                                        if r not in filtered_records
+                                    ]
                                     if len(recordID_filtered) == 0:
                                         if len(recordID_new) == 0:
                                             logger.debug(
@@ -510,14 +635,20 @@ def map_data(data, mapping_table, version, **kwargs):
                                 for attr_val in attr_vals:
                                     recordID_new = _map_attribute(
                                         attr_val,
-                                        data[intm[attr]["base"]][intm_table_alias]["records"],
+                                        data[intm[attr]["base"]][intm_table_alias][
+                                            "records"
+                                        ],
                                         (
                                             [intm[attr]["map_by_key"]]
                                             if isinstance(intm[attr]["map_by_key"], str)
                                             else intm[attr]["map_by_key"]
                                         ),
                                     )
-                                    recordID_filtered = [r for r in recordID_new if r not in filtered_records]
+                                    recordID_filtered = [
+                                        r
+                                        for r in recordID_new
+                                        if r not in filtered_records
+                                    ]
                                     if len(recordID_filtered) == 0:
                                         if len(recordID_new) == 0:
                                             logger.debug(
@@ -549,9 +680,13 @@ def map_data(data, mapping_table, version, **kwargs):
                                 # This case can actually happen for the 'Coordinate and Dimension' table
                                 # raise KeyError(errmsg)
                             try:
-                                mapped_data["Data Request"][table]["records"][record_id][
+                                mapped_data["Data Request"][table]["records"][
+                                    record_id
+                                ][
                                     mapinfo["internal_consistency"].get(attr, attr)
-                                ] = list(set(recordIDs_new))
+                                ] = list(
+                                    set(recordIDs_new)
+                                )
                             except KeyError:
                                 logger.debug(
                                     f"Consolidation of {table}@{intm_table_alias}:"
@@ -561,10 +696,18 @@ def map_data(data, mapping_table, version, **kwargs):
             else:
                 if mapinfo["source_base"] not in data:
                     missing_bases.append(mapinfo["source_base"])
-                elif all([st not in data[mapinfo["source_base"]] for st in mapinfo["source_table"]]):
+                elif all(
+                    [
+                        st not in data[mapinfo["source_base"]]
+                        for st in mapinfo["source_table"]
+                    ]
+                ):
                     missing_tables.append(mapinfo["source_table"][0])
         if len(missing_bases) > 0:
-            errmsg = "Encountered missing bases when consolidating the data:" f" {set(missing_bases)}"
+            errmsg = (
+                "Encountered missing bases when consolidating the data:"
+                f" {set(missing_bases)}"
+            )
             logger.critical(errmsg)
             raise KeyError(errmsg)
         if len(missing_tables) > 0:
@@ -585,7 +728,9 @@ def map_data(data, mapping_table, version, **kwargs):
         mapped_data = next(iter(data.values()))
         mapped_data = _apply_consistency_fixes(mapped_data)
         # String fixes
-        logger.debug("Consolidation: Removing / Adding (un)necessary whitespace to strings.")
+        logger.debug(
+            "Consolidation: Removing / Adding (un)necessary whitespace to strings."
+        )
         _fix_str_nested(mapped_data)
         mapped_data["version"] = version
         return {"Data Request": mapped_data}

--- a/data_request_api/data_request_api/content/mapping_table.py
+++ b/data_request_api/data_request_api/content/mapping_table.py
@@ -248,13 +248,19 @@ mapping_table = {
             },
         },
         "internal_filters": {},
-        "drop_keys": ["Modeling Realm (from CMOR Variables)", "Structure Title (from CMOR Variables)", "V1.1"],
+        "drop_keys": [
+            "Modeling Realm (from CMOR Variables)",
+            "Structure Title (from CMOR Variables)",
+            "V1.1",
+        ],
         "internal_consistency": {
             "CF Standard Name (from MIP Variables) 2 (from CMOR Variables)": (
                 "CF Standard Name (from Physical Parameter) (from Variables)"
             ),
             "CMOR Variables": "Variables",
-            "MIP Variables (from CMOR Variables)": ("Physical Parameter (from Variables)"),
+            "MIP Variables (from CMOR Variables)": (
+                "Physical Parameter (from Variables)"
+            ),
             "Title (from CMOR Variables)": "Title (from Variables)",
             "Units": "Units (from Physical Parameter) (from Variables)",
         },
@@ -306,7 +312,9 @@ mapping_table = {
         "internal_filters": {},
         "drop_keys": [],
         "internal_consistency": {
-            "Unique list of variables attached to Opportunity (linked) (from Opportunity)": ("Variables")
+            "Unique list of variables attached to Opportunity (linked) (from Opportunity)": (
+                "Variables"
+            )
         },
         "field_dtypes": {},
     },
@@ -594,7 +602,6 @@ mapping_table = {
             "Cross-thematic group review comment",
             "Cross-thematic team review",
             "Earth system author team review",
-            "Extra Dimensions",
             "Impacts & adaptation author team review",
             "Land & land-ice author team review",
             "Ocean & sea-ice author team review",
@@ -608,12 +615,14 @@ mapping_table = {
             "Structure Title",
             "Theme",
             "Variable is included in ESM-BCV v1.3",
+            "variableRootDD (from Physical Parameter)",
         ],
         "internal_consistency": {
             "CF Standard Name (from MIP Variables)": "CF Standard Name (from Physical Parameter)",
             "Compound name": "CMIP6 Compound Name",
             "Compound Name": "CMIP6 Compound Name",
             "ESM-BCV 1.3": "ESM-BCV 1.4",
+            "Extra Dimensions": "Extra dimensions",
             "Min Rank": "Min Rank in CMIP6 download statistics",
             "Modeling Realm": "Modelling Realm - Primary",
             "Modeling Realm - Primary": "Modelling Realm - Primary",
@@ -687,7 +696,7 @@ version_consistency_fields = {
         "MIPs": "Of interest to MIPs",
     },
     "Variables": {
-        "Contitional": "Conditional",
+        "Contitional": "Conditional",  # noqa
         "Compound name": "CMIP6 Compound Name",
         "Compound Name": "CMIP6 Compound Name",
         "ESM-BCV 1.3": "ESM-BCV 1.4",
@@ -722,7 +731,16 @@ version_consistency_drop_fields = {
         "Proposed CF Standard Name",
     ],
     "Priority Level": ["Last Modified By"],
-    "Spatial Shape": ["Hor Label DD", "Structure", "Vertical Label DD", "Vertical Label MM"],
+    "Spatial Shape": [
+        "Hor Label DD",
+        "Structure",
+        "Vertical Label DD",
+        "Vertical Label MM",
+    ],
     "Temporal Shape": ["Brand", "Structure"],
-    "Variables": ["Proposed CF Standard Name (for new Physical Parameters)", "Structure Label", "Structure Title"],
+    "Variables": [
+        "Proposed CF Standard Name (for new Physical Parameters)",
+        "Structure Label",
+        "Structure Title",
+    ],
 }

--- a/scripts/check_consolidation2_list-all-diffs.py
+++ b/scripts/check_consolidation2_list-all-diffs.py
@@ -1,0 +1,569 @@
+import re
+import sys
+from collections import defaultdict
+
+import data_request_api.content.consolidate_export as ce
+import data_request_api.content.dreq_content as dc
+from data_request_api.utilities.logger import (
+    change_log_file,
+    change_log_level,
+    get_logger,
+)
+
+# Print consolidation log and full list of unmatched records
+long_summary = True
+
+change_log_file(default=True)
+if long_summary:
+    change_log_level("debug")
+else:
+    change_log_level("critical")
+logger = get_logger()
+
+if len(sys.argv) > 1:
+    version = sys.argv[1]
+else:
+    print(
+        "Please provide a version as first argument and optionally 'md' as second argument to generate markdown output:"
+    )
+    print("python", sys.argv[0], "<version> [md]")
+    sys.exit(1)
+
+# Whether to use Markdown/html formatting
+if len(sys.argv) > 2 and sys.argv[2] == "md":
+    h1s = "<h1>"
+    h1e = "</h1>"
+    h2s = "<h2>"
+    h2e = "</h2>"
+    h3s = "<h3>"
+    h3e = "</h3>"
+    h4s = "<h4>"
+    h4e = "</h4>"
+    dets = "<details>"
+    dete = "</details>"
+    sums = "<summary>"
+    sume = "</summary>"
+    code = "```"
+    code1 = "`"
+elif len(sys.argv) > 2 and sys.argv[2] != "md":
+    print("ERROR Unknown argument:", sys.argv[2])
+else:
+    h1s = ""
+    h1e = ""
+    h2s = ""
+    h2e = ""
+    h3s = ""
+    h3e = ""
+    h4s = ""
+    h4e = ""
+    dets = ""
+    dete = ""
+    sums = ""
+    sume = ""
+    code = ""
+    code1 = ""
+
+offlineRAW = version in dc.get_cached(export="raw")
+offlineREL = version in dc.get_cached(export="release")
+
+if not h1s:
+    print("#" * 50)
+print(f"{h1s}Checking consolidation of '{version}'{h1e}")
+if not h1s:
+    print("#" * 50)
+print(f"{dets}")
+
+
+# Load raw export with consolidation
+if long_summary:
+    if not h1s:
+        print("-" * 50)
+    print(f"{sums}{h2s}Consolidation log for raw export{h2e}{sume}")
+    if not h1s:
+        print("-" * 50)
+    if code:
+        print()
+    print(f"{code}")
+dreqraw = dc.load(
+    version,
+    export="raw",
+    consolidate=True,
+    offline=offlineRAW,
+    force_consolidate=True,
+)
+if long_summary:
+    print(f"{code}")
+    if code:
+        print()
+    print(f"{dete}")
+    if dete:
+        print()
+
+# Load release export with consolidation
+if long_summary:
+    print(f"{dets}")
+    if dets:
+        print()
+    if not h1s:
+        print("-" * 50)
+    print(f"{sums}{h2s}Consolidation log for release export{h2e}{sume}")
+    if not h1s:
+        print("-" * 50)
+    if code:
+        print()
+    print(f"{code}")
+dreqrel = dc.load(
+    version, export="release", consolidate=True, offline=offlineREL
+)
+if long_summary:
+    print(f"{code}")
+    if code:
+        print()
+    print(f"{dete}")
+    if dete:
+        print()
+
+
+def compare_dicts(raw, rel):
+    print()
+    rid_uid_map_raw = ce._gen_rid_uid_map(raw["Data Request"])
+    rid_uid_map_rel = ce._gen_rid_uid_map(rel["Data Request"])
+    print(f"- {len(ce.filtered_records)} filtered records")
+    print(
+        f"- {len(rid_uid_map_raw.keys())} rid->UID mapping entries (raw export)"
+    )
+    print(
+        f"- {len(rid_uid_map_rel.keys())} rid->UID mapping entries (release export)"
+    )
+    print()
+
+    if len(raw["Data Request"].keys()) != len(rel["Data Request"].keys()):
+        print("ERROR: Different number of tables")
+    if raw["Data Request"]["version"] != rel["Data Request"]["version"]:
+        print("ERROR: Differing versions")
+
+    # Clear version
+    version = raw["Data Request"].pop("version")
+    rel["Data Request"].pop("version")
+
+    # Collect differences in dictionaries
+    matches = defaultdict(lambda: defaultdict())
+    matches_uid = defaultdict(lambda: defaultdict())
+    examples = defaultdict(lambda: defaultdict())
+    diff_fields_count = defaultdict(lambda: defaultdict(int))
+    diff_string_count = defaultdict(
+        lambda: defaultdict(lambda: defaultdict(int))
+    )
+    diff_rec_count = defaultdict(lambda: defaultdict(lambda: defaultdict(int)))
+    diff_rec = defaultdict(
+        lambda: defaultdict(lambda: defaultdict(lambda: defaultdict(list)))
+    )
+
+    # Comparison for each table and field and record
+    for table_i in raw["Data Request"]:
+        print()
+        print("-" * 50)
+        print(
+            f'{table_i}    (# records - raw: {len(raw["Data Request"][table_i]["records"].keys())} - release: {len(rel["Data Request"][table_i]["records"].keys())})'
+        )
+        print("-" * 50)
+        print()
+        if table_i not in rel["Data Request"]:
+            print(
+                f"ERROR: '{table_i}' is missing or named differently in release export"
+            )
+            continue
+
+        # Compare table definition
+        #  todo
+
+        # Compare fields definition
+        #  todo
+
+        # Compare records
+        nomatch = defaultdict(list)
+        mltmatch = defaultdict(list)
+        for rawid, rawrec in raw["Data Request"][table_i]["records"].items():
+            # CMIP7 Compound Name is in raw export only for v1.2
+            if version == "v1.2" and table_i == "Variables":
+                rawrec.pop("CMIP7 Compound Name")
+
+            # Match raw and release records via UID (not possible pre v1.2)
+            relid = [
+                rid
+                for rid in rel["Data Request"][table_i]["records"].keys()
+                if rel["Data Request"][table_i]["records"][rid]["UID"]
+                == rawrec["UID"]
+            ]
+            if len(relid) == 0:
+                nomatch[table_i].append(rawrec["UID"])
+                continue
+            elif len(relid) > 1:
+                mltmatch[table_i].append(rawrec["UID"])
+            relid = relid[0]
+            relrec = rel["Data Request"][table_i]["records"][relid]
+            matches_uid[table_i][rawid] = relid
+
+            # "Image" field in Opportunity table is a nested dictionary and not relevant - so skip this field
+            if table_i == "Opportunity" and "Image" in relrec:
+                relrec.pop("Image")
+            if table_i == "Opportunity" and "Image" in rawrec:
+                rawrec.pop("Image")
+
+            # Compare records to find fields that differ
+            # Distinguish
+            #  - match: all fields match
+            #  - fmatch: current field matches
+            # If fields reference other record(s), compare only referenced UIDs
+            match = True
+            for fld in set(rawrec.keys()) | set(relrec.keys()):
+                fmatch = True
+                if fld not in relrec.keys():
+                    if rawrec[fld]:
+                        match = False
+                        fmatch = False
+                        if isinstance(rawrec[fld], list) and any(
+                            [item.startswith("rec") for item in rawrec[fld]]
+                        ):
+                            diff_rec_count[table_i][fld]["rawmore"] += 1
+                            diff_rec_count[table_i][fld]["rawmoreuids"] += 1
+                            rawuids = {
+                                rid_uid_map_raw[ridx] for ridx in rawrec[fld]
+                            }
+                            diff_rec[table_i][fld]["raw"][rawrec["UID"]] = list(
+                                rawuids
+                            )
+                    else:
+                        continue
+                elif fld not in rawrec.keys():
+                    if relrec[fld]:
+                        match = False
+                        fmatch = False
+                        if isinstance(relrec[fld], list) and any(
+                            [item.startswith("rec") for item in relrec[fld]]
+                        ):
+                            diff_rec_count[table_i][fld]["relmore"] += 1
+                            diff_rec_count[table_i][fld]["relmoreuids"] += 1
+                            reluids = {
+                                rid_uid_map_rel[ridx] for ridx in relrec[fld]
+                            }
+                            diff_rec[table_i][fld]["rel"][relrec["UID"]] = list(
+                                reluids
+                            )
+                    else:
+                        continue
+                elif not rawrec[fld] and not relrec[fld]:
+                    continue
+                elif not isinstance(rawrec[fld], type(relrec[fld])) and (
+                    rawrec[fld] or relrec[fld]
+                ):
+                    match = False
+                    fmatch = False
+                elif isinstance(rawrec[fld], list) and any(
+                    [
+                        item.startswith("rec")
+                        for item in rawrec[fld]
+                        if isinstance(item, str)
+                    ]
+                ):
+                    rawuids = {rid_uid_map_raw[ridx] for ridx in rawrec[fld]}
+                    reluids = {rid_uid_map_rel[ridx] for ridx in relrec[fld]}
+                    if not len(rawrec[fld]) == len(relrec[fld]):
+                        match = False
+                        fmatch = False
+                        if len(rawrec[fld]) > len(relrec[fld]):
+                            diff_rec_count[table_i][fld]["rawmore"] += 1
+                        else:
+                            diff_rec_count[table_i][fld]["relmore"] += 1
+                        if len(
+                            [
+                                rid
+                                for rid in rawrec[fld]
+                                if rid not in ce.filtered_records
+                            ]
+                        ) < len(rawrec[fld]):
+                            diff_rec_count[table_i][fld]["unfiltered"] += 1
+                            diff_rec_count[table_i][fld][rawrec["UID"]] = len(
+                                rawrec[fld]
+                            ) - len(
+                                [
+                                    rid
+                                    for rid in rawrec[fld]
+                                    if rid not in ce.filtered_records
+                                ]
+                            )
+                    if len(rawuids) == len(reluids):
+                        diff_rec_count[table_i][fld]["samenruids"] += 1
+                    if rawuids != reluids:
+                        match = False
+                        fmatch = False
+                        diff_rec[table_i][fld]["raw"][rawrec["UID"]] = [
+                            uid for uid in rawuids if uid not in reluids
+                        ]
+                        diff_rec[table_i][fld]["rel"][relrec["UID"]] = [
+                            uid for uid in reluids if uid not in rawuids
+                        ]
+                        if len(rawuids) > len(reluids):
+                            diff_rec_count[table_i][fld]["rawmoreuids"] += 1
+                        elif len(rawuids) < len(reluids):
+                            diff_rec_count[table_i][fld]["relmoreuids"] += 1
+                    else:
+                        diff_rec_count[table_i][fld]["sameuids"] += 1
+                elif isinstance(rawrec[fld], list):
+                    if not sorted(rawrec[fld]) == sorted(relrec[fld]):
+                        match = False
+                        fmatch = False
+                elif rawrec[fld] != relrec[fld]:
+                    match = False
+                    fmatch = False
+                    if isinstance(rawrec[fld], str):
+                        if re.sub(r"\s+", "", rawrec[fld]) == re.sub(
+                            r"\s+", "", relrec[fld]
+                        ):
+                            diff_string_count[table_i][fld]["ws"] += 1
+                        elif rawrec[fld].lower() == relrec[fld].lower():
+                            diff_string_count[table_i][fld]["c"] += 1
+                        elif (
+                            re.sub(r"\s+", "", rawrec[fld]).lower()
+                            == re.sub(r"\s+", "", relrec[fld]).lower()
+                        ):
+                            diff_string_count[table_i][fld]["wsc"] += 1
+                if not fmatch:
+                    if fld in examples[table_i]:
+                        examples[table_i][fld].append( [
+                            rawrec[fld] if fld in rawrec else "UNDEFINED",
+                            relrec[fld] if fld in relrec else "UNDEFINED",
+                            rawrec["UID"],
+                        ])
+                    else:
+                        examples[table_i][fld] = list()
+                        examples[table_i][fld].append([
+                           rawrec[fld] if fld in rawrec else "UNDEFINED",
+                           relrec[fld] if fld in relrec else "UNDEFINED",
+                           rawrec["UID"],
+                        ])
+
+                    diff_fields_count[table_i][fld] += 1
+            if match:
+                matches[table_i][rawid] = relid
+
+        print(f"Perfect matches: {len(list(set(matches[table_i].keys())))}")
+        if len(list(set(matches[table_i].keys()))) != len(
+            raw["Data Request"][table_i]["records"].keys()
+        ):
+            print(
+                f"Matches by UID: {len(list(set(matches_uid[table_i].keys())))}"
+            )
+        # release UIDs not in raw
+        rel_unique = [
+            rid_uid_map_rel[rel_recid]
+            for rel_recid in rel["Data Request"][table_i]["records"].keys()
+            if rid_uid_map_rel[rel_recid]
+            not in [
+                rid_uid_map_raw[raw_recid]
+                for raw_recid in raw["Data Request"][table_i]["records"].keys()
+            ]
+        ]
+        if rel_unique:
+            print(dets)
+            print(
+                f"{sums}Unique UIDs in release export: {len(rel_unique)}{sume}"
+            )
+            print()
+            for uid in sorted(rel_unique):
+                print(f"  - {uid}")
+            print(dete)
+        # raw UIDs not in release
+        if nomatch[table_i]:
+            if long_summary:
+                print(dets)
+                print(f"{sums}No matches: {len(nomatch[table_i])}{sume}")
+                print()
+                for uid in nomatch[table_i]:
+                    print(f"  - {uid}")
+                print(dete)
+            else:
+                print(f"No matches: {len(nomatch[table_i])}")
+        if mltmatch[table_i]:
+            if long_summary:
+                print(dets)
+                print(f"{sums}Multiple matches: {len(mltmatch[table_i])}{sume}")
+                print()
+                for uid in mltmatch[table_i]:
+                    print(f"  - {uid}")
+                print(dete)
+            else:
+                print(f"Multiple matches: {len(mltmatch[table_i])}")
+        if len(examples[table_i].keys()) > 0:
+            print()
+            print(f"{h4s}Differences occurred for the following fields:{h4e}")
+            print()
+            for fld in diff_fields_count[table_i]:
+                diffstr = ""
+                if diff_string_count[table_i][fld]["ws"]:
+                    diffstr += (
+                        f"whitespace {diff_string_count[table_i][fld]['ws']}, "
+                    )
+                if diff_string_count[table_i][fld]["c"]:
+                    diffstr += f"case {diff_string_count[table_i][fld]['c']}, "
+                if diff_string_count[table_i][fld]["wsc"]:
+                    diffstr += f"whitespace&case {diff_string_count[table_i][fld]['wsc']}, "
+                diffrecs = ""
+                if diff_rec_count[table_i][fld]["rawmore"]:
+                    diffrecs += f" (more records in raw export in {diff_rec_count[table_i][fld]['rawmore']} cases)"
+                if diff_rec_count[table_i][fld]["unfiltered"]:
+                    diffrecs += f" (unfiltered records encountered {diff_rec_count[table_i][fld]['unfiltered']} times)"
+                    if (
+                        diff_rec_count[table_i][fld]["rawmore"]
+                        + diff_rec_count[table_i][fld]["relmore"]
+                        != diff_fields_count[table_i][fld]
+                    ):
+                        print(
+                            f"ERROR counting differences for '{table_i}'@'{fld}': {diff_rec_count[table_i][fld]['rawmore']} + {diff_rec_count[table_i][fld]['relmore']} != {diff_fields_count[table_i][fld]}"
+                        )
+                if diff_rec_count[table_i][fld]["rawmoreuids"]:
+                    diffrecs += f" (More UIDs raw: {diff_rec_count[table_i][fld]['rawmoreuids']} cases)"
+                if diff_rec_count[table_i][fld]["relmoreuids"]:
+                    diffrecs += f" (More UIDs release: {diff_rec_count[table_i][fld]['relmoreuids']} cases)"
+                if diff_rec_count[table_i][fld]["samenruids"]:
+                    diffrecs += f" (Same number of UIDs: {diff_rec_count[table_i][fld]['samenruids']} cases)"
+                if diff_rec_count[table_i][fld]["sameuids"]:
+                    diffrecs += f" (Exact same UIDs: {diff_rec_count[table_i][fld]['sameuids']} cases)"
+                print(
+                    f"- {diff_fields_count[table_i][fld]} for field '{fld}' {'(Differences only in: ' + diffstr.strip(', ') + ')' if diffstr else ''}{diffrecs if diffrecs else ''}"
+                )
+            if dets:
+                print()
+            print(dets)
+            print(f"{sums}Examples:{sume}")
+            if dets:
+                print()
+            for fld in examples[table_i].keys():
+                for ex in examples[table_i][fld]:
+                    print(
+                        f"{h4s}Field '{fld}' in table '{table_i}'       UID: '{ex[2]}'{h4e}"
+                    )
+                    if code:
+                        print()
+                    if isinstance(ex[1], list) and any(
+                        [
+                            item.startswith("rec")
+                            for item in ex[1]
+                            if isinstance(item, str)
+                        ]
+                    ):
+                        print(
+                            f"- release: List of record ids with {len(ex[1])} elements"
+                        )
+                        print(
+                            f"  - unique UIDs in release {diff_rec[table_i][fld]['rel'][ex[2]]}"
+                        )
+                    elif isinstance(ex[1], str):
+                        print("- release:")
+                        if code:
+                            print()
+                        print(code)
+                        print(f"'{ex[1]}'")
+                        print(code)
+                        if code:
+                            print()
+                    else:
+                        print(
+                            f"- release: {code1}{ex[1]}{code1}"
+                        )
+                    if isinstance(ex[0], list) and any(
+                        [
+                            item.startswith("rec")
+                            for item in ex[0]
+                            if isinstance(item, str)
+                        ]
+                    ):
+                        print(
+                            f"- raw: List of record ids with {len(ex[0])} elements"
+                        )
+                        print(
+                            f"  - unique UIDs in raw {diff_rec[table_i][fld]['raw'][ex[2]]}"
+                        )
+                    elif isinstance(ex[0], str):
+                        print("- raw:")
+                        if code:
+                            print()
+                        print(code)
+                        print(f"'{ex[0]}'")
+                        print(code)
+                        if code:
+                            print()
+                    else:
+                        print(f"- raw: {code1}{ex[0]}{code1}")
+            if dete:
+                print()
+            if dete:
+                print(dete)
+            if dete:
+                print()
+            printsummary = False
+            for fld in examples[table_i].keys():
+                if (
+                    isinstance(examples[table_i][fld][0][1], list)
+                    and any(
+                        [
+                            item.startswith("rec")
+                            for item in examples[table_i][fld][0][1]
+                            if isinstance(item, str)
+                        ]
+                    )
+                ) or (
+                    isinstance(examples[table_i][fld][0][0], list)
+                    and any(
+                        [
+                            item.startswith("rec")
+                            for item in examples[table_i][fld][0][0]
+                            if isinstance(item, str)
+                        ]
+                    )
+                ):
+                    printfld = False
+                    uidlist = []
+                    if diff_rec[table_i][fld]["raw"]:
+                        uidlist.extend(
+                            list(diff_rec[table_i][fld]["raw"].keys())
+                        )
+                    if diff_rec[table_i][fld]["rel"]:
+                        uidlist.extend(
+                            list(diff_rec[table_i][fld]["rel"].keys())
+                        )
+                    for uid in set(uidlist):
+                        if (
+                            diff_rec[table_i][fld]["raw"][uid]
+                            or diff_rec[table_i][fld]["rel"][uid]
+                        ):
+                            if not printsummary:
+                                if dets:
+                                    print()
+                                print(dets)
+                                print(
+                                    f"{sums}Full differences in record references (listed as UIDs):{sume}"
+                                )
+                                print()
+                                printsummary = True
+                            if not printfld:
+                                print(f"- '{fld}' ({table_i})")
+                                printfld = True
+                            print(f"  - {uid}")
+                            if diff_rec[table_i][fld]["raw"][uid]:
+                                print(
+                                    f"    - unique in raw ({len(diff_rec[table_i][fld]['raw'][uid])}):",
+                                    diff_rec[table_i][fld]["raw"][uid],
+                                )
+                            if diff_rec[table_i][fld]["rel"][uid]:
+                                print(
+                                    f"    - unique in release ({len(diff_rec[table_i][fld]['rel'][uid])}):",
+                                    diff_rec[table_i][fld]["rel"][uid],
+                                )
+            if printsummary:
+                print(dete)
+                if dete:
+                    print()
+
+
+compare_dicts(dreqraw, dreqrel)


### PR DESCRIPTION
This updates the consolidation for v1.2.2 and does not contain major changes. For some reason the consolidation of v1.2 was not working anymore because strings that needed to be converted to integers, like `"16,400"` caused an error now, so that was fixed as well.

- mapping_table.py updated for v1.2.2
- consolidate_export.py: added fix for strings representing numeric values but with illegal characters
- added check_consolidation2_list-all-diffs.py to list all differences between raw and release export of a certain version